### PR TITLE
feat: add EmailRecognizer for email address detection using regex

### DIFF
--- a/docs/iteration_1_planering.md
+++ b/docs/iteration_1_planering.md
@@ -473,3 +473,28 @@ Lägg till en ny post längst ner. Använd följande mall:
 - Issue #7: `recognizers/telefon.py` (regex för svenska telefonnummer).
 - Issue #8: `recognizers/iban.py` (regex + mod97).
 - Issue #10: `PatternLayer` som itererar registrerade recognizers.
+
+#### Session 2026-04-17 - Cursor agent (Opus 4.7)
+
+**Iteration:** 1 (v0.1.0), pipeline-spåret steg 3
+**Mål:** Implementera `EmailRecognizer` (Issue #6) som regex-baserad recognizer för e-postadresser.
+
+**Ändrade filer:**
+- `gdpr_classifier/layers/pattern/recognizers/email.py` - `EmailRecognizer` (stdlib `re`, case-insensitive regex, emitterar `Finding` med `source="pattern.regex_email"` och `confidence=1.0`).
+- `gdpr_classifier/layers/pattern/recognizers/__init__.py` - re-exporterar `EmailRecognizer` via `__all__` (alfabetisk ordning).
+
+**Gjort:**
+- Kompilerad regex `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` med `re.IGNORECASE` - täcker punkt, bindestreck, understreck och plus i local part, domän med minst en punkt och TLD på minst 2 bokstäver.
+- `Finding` byggs med `match.start()`/`match.end()`/`match.group()` i en loop över `finditer`, analogt med `personnummer.py`-mönstret.
+- Avslutande interpunktion (t.ex. `"anna@test.se."`) hamnar inte i spanet eftersom TLD-delen `[a-zA-Z]{2,}` bara accepterar bokstäver; regex-motorns backtracking stannar på sista bokstavsgruppen.
+- `ReadLints` rena på båda filerna. Inga tester skrivna (egna issues).
+- Inga ändringar i `core/` eller `docs/arkitektur.md` - avsnitt 4.2 matchade redan koden (`source="pattern.regex_email"`, `confidence=1.0`).
+
+**Beslut fattade:**
+- Inga avvikelser från SSOT. Följde exakt samma filstruktur, import-ordning och klassmönster som `PersonnummerRecognizer` för konsistens inom `recognizers/`-paketet.
+- `re.IGNORECASE` adderad trots att regex-teckenklasser redan täcker båda casen - defensiv mot framtida förenklingar av mönstret.
+
+**Öppet/Nästa steg:**
+- Issue #7: `recognizers/telefon.py` (regex för svenska telefonnummer, `source="pattern.regex_telefon"`, `confidence=0.9`).
+- Issue #8: `recognizers/iban.py` (regex + mod97, `source="pattern.checksum_iban"`).
+- Issue #10: `PatternLayer` som itererar registrerade recognizers.

--- a/gdpr_classifier/layers/pattern/recognizers/__init__.py
+++ b/gdpr_classifier/layers/pattern/recognizers/__init__.py
@@ -7,6 +7,7 @@ numbers, and IBAN.
 
 from __future__ import annotations
 
+from .email import EmailRecognizer
 from .personnummer import PersonnummerRecognizer
 
-__all__ = ["PersonnummerRecognizer"]
+__all__ = ["EmailRecognizer", "PersonnummerRecognizer"]

--- a/gdpr_classifier/layers/pattern/recognizers/email.py
+++ b/gdpr_classifier/layers/pattern/recognizers/email.py
@@ -1,6 +1,40 @@
-"""Email address recognizer.
+"""Email address recognizer (regex)."""
 
-Detects email addresses in text using a regular expression and
-reports each match as a Finding in the appropriate GDPR contact
-data category.
-"""
+from __future__ import annotations
+
+import re
+
+from gdpr_classifier.core import Category, Finding
+
+_PATTERN = re.compile(
+    r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+    re.IGNORECASE,
+)
+
+
+class EmailRecognizer:
+    """Recognizer for email addresses via regex."""
+
+    @property
+    def category(self) -> Category:
+        return Category.EMAIL
+
+    @property
+    def source_name(self) -> str:
+        return "regex_email"
+
+    def recognize(self, text: str) -> list[Finding]:
+        findings: list[Finding] = []
+        for match in _PATTERN.finditer(text):
+            findings.append(
+                Finding(
+                    category=Category.EMAIL,
+                    start=match.start(),
+                    end=match.end(),
+                    text_span=match.group(),
+                    confidence=1.0,
+                    source="pattern.regex_email",
+                    metadata=None,
+                )
+            )
+        return findings


### PR DESCRIPTION
- Implemented EmailRecognizer in `gdpr_classifier/layers/pattern/recognizers/email.py` with a case-insensitive regex pattern.
- Updated `__init__.py` to re-export EmailRecognizer.
- Documented the implementation details and next steps in `iteration_1_planering.md`.