### PR TITLE
feat: extend email regex to support Swedish characters for IDN domains

### DIFF
--- a/docs/arkitektur.md
+++ b/docs/arkitektur.md
@@ -232,6 +232,7 @@ class Recognizer(Protocol):
 
 **E-post** (`email.py`):
 - Matchar standardformat via regex.
+- Teckenklasser i lokal- och domändel accepterar svenska bokstäver (å, ä, ö) för att stödja IDN-domäner som `företaget.se`. Punycode/xn-- ligger utanför iteration 1.
 - `source`: `"pattern.regex_email"`
 - `confidence`: 1.0
 

--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -390,3 +390,22 @@ Lägg till en ny post längst ner. Använd följande mall:
 
 ### Poster
 
+#### Session 2026-04-18 - Cursor-agent (Opus)
+
+**Iteration:** 1 / v0.1.1
+**Mål:** Lösa issue #37 - utöka email-regex för IDN-domäner med svenska tecken (å, ä, ö).
+
+**Ändrade filer:**
+- `gdpr_classifier/layers/pattern/recognizers/email.py` - teckenklasser i lokal- och domändel utökade med `åäöÅÄÖ`; `-` explicit escapad (`\-`).
+- `docs/arkitektur.md` - avsnitt 4.2, E-post-bullet: rad om IDN-stöd för svenska tecken tillagd.
+- `docs/iteration_1_demoforberedelse.md` - denna sessionspost.
+
+**Gjort:**
+- Bytt `_PATTERN` i `email.py` enligt issue-spec; struktur, `source`, `confidence` och `IGNORECASE` oförändrade.
+- Kört `.venv\Scripts\python.exe run_evaluation.py`: `article4.email` TP=10, FP=0, FN=0 → recall 100% (upp från 9/10). Total: TP=43, FP=2, FN=1, precision 95.56%, recall 97.73%, F1 96.63%. `info@företaget.se` ej längre i FN-sektionen.
+- Kört `.venv\Scripts\python.exe -m pytest tests/integration/test_end_to_end.py -s`: 1 passed.
+- `ReadLints` på `email.py`: rent.
+
+**Beslut fattade:** Behåller `[a-zA-Z]{2,}` i TLD-delen; punycode/xn-- och IDN-TLD ligger utanför iteration 1:s scope (SSOT 4.2).
+**Öppet/Nästa steg:** Kvarvarande FN/FP ligger i `article4.telefonnummer` (recall 90%, precision 81.82%) - hör till andra issues. Unit-tester för email-edge cases vid behov i senare issue. Commit sker efter granskning (ingen commit i denna session).
+

--- a/gdpr_classifier/layers/pattern/recognizers/email.py
+++ b/gdpr_classifier/layers/pattern/recognizers/email.py
@@ -7,7 +7,7 @@ import re
 from gdpr_classifier.core import Category, Finding
 
 _PATTERN = re.compile(
-    r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+    r"[a-zA-Z0-9._%+\-åäöÅÄÖ]+@[a-zA-Z0-9.\-åäöÅÄÖ]+\.[a-zA-Z]{2,}",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
- Updated the email regex pattern in `email.py` to include Swedish characters (å, ä, ö) for local and domain parts, enhancing support for IDN domains.
- Added documentation in `arkitektur.md` to reflect this change and its implications for email validation.
- Documented the session details in `iteration_1_demoforberedelse.md`, outlining the goals and changes made for issue #37.