### PR TITLE
feat: enhance telefonnummer regex to support optional balanced parentheses for country code

### DIFF
--- a/docs/arkitektur.md
+++ b/docs/arkitektur.md
@@ -238,6 +238,7 @@ class Recognizer(Protocol):
 
 **Telefonnummer** (`telefon.py`):
 - Matchar svenska telefonnummer (07X-XXX XX XX, +46-XXX-XXX XX XX, varianter).
+- Stödjer valfria balanserade parenteser runt landskoden (t.ex. `(+46)70 999 88 77`, `(0046)...`); domestikt prefix `0` omfattas inte av parentes-varianten.
 - `source`: `"pattern.regex_telefon"`
 - `confidence`: 0.9 (telefonnummer-regex ger fler falska positiva än Luhn-validerade personnummer).
 

--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -409,3 +409,22 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Behåller `[a-zA-Z]{2,}` i TLD-delen; punycode/xn-- och IDN-TLD ligger utanför iteration 1:s scope (SSOT 4.2).
 **Öppet/Nästa steg:** Kvarvarande FN/FP ligger i `article4.telefonnummer` (recall 90%, precision 81.82%) - hör till andra issues. Unit-tester för email-edge cases vid behov i senare issue. Commit sker efter granskning (ingen commit i denna session).
 
+#### Session 2026-04-18 - Cursor-agent (Opus)
+
+**Iteration:** 1 / v0.1.1
+**Mål:** Lösa issue #38 - utöka telefon-regex så att `+46`/`0046` får omges av balanserade parenteser (t.ex. `(+46)70 999 88 77`).
+
+**Ändrade filer:**
+- `gdpr_classifier/layers/pattern/recognizers/telefon.py` - prefix-alternationen utökad med `\((?:\+46|0046)\)` som första gren; `source`, `confidence`, lookbehind `(?<![\d+])`, separators och boundaries oförändrade.
+- `docs/arkitektur.md` - avsnitt 4.2, Telefonnummer-bullet: rad om stöd för valfria balanserade parenteser runt landskoden tillagd.
+- `docs/iteration_1_demoforberedelse.md` - denna sessionspost.
+
+**Gjort:**
+- Bytt `_PATTERN` i `telefon.py` enligt issue-spec; parens-grenen placerad först i alternationen så motorn försöker den före bar-varianten.
+- Kört `.venv\Scripts\python.exe run_evaluation.py`: `article4.telefonnummer` TP=10, FP=2, FN=0 → recall 100% (upp från 90%), precision 83.33%. Total: TP=44, FP=2, FN=0, precision 95.65%, recall 100%, F1 97.78%. `(+46)70 999 88 77` ej längre i FN-sektionen; inga nya FP utöver de 2 befintliga IBAN-överlapps-FP:erna (#39).
+- Kört `.venv\Scripts\python.exe -m pytest tests/integration/test_end_to_end.py -s`: 1 passed.
+- `ReadLints` på `telefon.py`: rent.
+
+**Beslut fattade:** Parens-varianten omfattar endast `+46`/`0046`, inte domestikt `0` (FP-risk + inte i verkligt bruk). SSOT 4.2 uppdaterad i samma session.
+**Öppet/Nästa steg:** Kvarvarande 2 FP på telefon (IBAN-fragment som matchar telefon-regex) hör till issue #39. Commit sker efter granskning (ingen commit i denna session).
+

--- a/gdpr_classifier/layers/pattern/recognizers/telefon.py
+++ b/gdpr_classifier/layers/pattern/recognizers/telefon.py
@@ -8,7 +8,7 @@ from gdpr_classifier.core import Category, Finding
 
 _PATTERN = re.compile(
     r"(?<![\d+])"
-    r"(?:\+46|0046|0)"
+    r"(?:\((?:\+46|0046)\)|\+46|0046|0)"
     r"[-\s]?[1-9]"
     r"(?:[-\s]?\d){6,8}"
     r"(?!\d)"


### PR DESCRIPTION
- Updated the regex pattern in `telefon.py` to allow for optional balanced parentheses around the country code (+46/0046).
- Added documentation in `arkitektur.md` to reflect this new feature for Swedish phone number recognition.
- Documented session details in `iteration_1_demoforberedelse.md`, outlining the goals and changes made for issue #38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced phone number pattern recognition to support country code prefixes wrapped in parentheses, such as `(+46)` and `(0046)`, in addition to standard international and domestic prefixes.

* **Documentation**
  * Updated technical documentation to reflect expanded phone number recognizer capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->