### PR TITLE
docs: document IBAN-telefon FP as known limitation (#39)

### DIFF
--- a/docs/arkitektur.md
+++ b/docs/arkitektur.md
@@ -575,7 +575,20 @@ Ska aggregatorn vikta fynd baserat på konfidens? I iteration 1 är alla fynd bi
 Kan en textbit tillhöra flera GDPR-kategorier samtidigt? Exempelvis ett namn som också avslöjar etniskt ursprung (Artikel 4 + Artikel 9). Nuvarande modell stöder detta genom att flera fynd kan rapporteras med överlappande span men olika kategorier.
 
 
-## 14. Referenser
+## 14. Kända begränsningar (iteration 1)
+
+Utvärderingen på testdatat i iteration 1 visar två återstående falska positiva som båda produceras av samma systeminteraktion. Telefon-recognizern (`pattern.regex_telefon`) matchar siffersekvenser som också ingår i fynd från IBAN-recognizern (`pattern.checksum_iban`), eftersom svenska telefonnummer och IBAN:ens BBAN-segment delar numerisk struktur (sifferblock separerade med mellanslag). Fenomenet är alltså inte en felaktighet i telefon-regexen i isolation, utan en konsekvens av att två recognizers arbetar oberoende på samma text.
+
+Konkret rör det följande två fall i testdatat: textspanet `"0555 5555 55"` matchas som telefonnummer inom IBAN-fyndet `SE96 5000 0000 0555 5555 55`, och textspanet `"05 1234 5678"` matchas som telefonnummer inom IBAN-fyndet `SE05 1234 5678 9012 3456 78`. Båda telefon-fynden ligger helt inneslutna i respektive IBAN-fynd.
+
+Grundorsaken sitter på aggregator-nivå, inte på recognizer-nivå. Varje recognizer i `PatternLayer` är designmässigt oberoende av övriga och känner inte till deras fynd (avsnitt 4.1). Aggregatorn registrerar överlapp mellan fynd i `overlapping_findings` (avsnitt 3.4) men reducerar inte fyndmängden utifrån detta - den beslutar om känslighetsnivå, inte om deduplicering. Telefon-fynden rapporteras därför som fullvärdiga fynd trots att de är inneslutna i ett fynd med högre konfidens.
+
+Begränsningen åtgärdas inte i iteration 1 eftersom en lösning kräver en aktiv reduktionsregel i aggregatorn, vilket är en arkitekturförändring som berör designprincip 3 (spårbarhet): ett filtrerat fynd får inte försvinna tyst utan måste fortfarande vara synligt i utvärderingen. En sådan förändring behöver dessutom diskuteras med intressenter under demon innan den implementeras, eftersom den påverkar vilken bild av artefaktens falska positiva som presenteras.
+
+Planerad åtgärd i iteration 2 (BIE-cykel 2): `Aggregator` utökas med en containment-regel som tar bort ett fynd från `findings` om det är helt inneslutet i ett fynd från en annan recognizer med strikt högre konfidens (till exempel 1.0 över 0.9). Det borttagna fyndet bevaras i `overlapping_findings` så spårbarheten mot designprincip 3 upprätthålls. Åtgärden planeras för iteration 2:s Build-fas. Denna issue (#39) dokumenterar enbart begränsningen som underlag för framtida arbete.
+
+
+## 15. Referenser
 
 Buschmann, F., Meunier, R., Rohnert, H., Sommerlad, P. & Stal, M. (1996). *Pattern-Oriented Software Architecture: A System of Patterns*. Chichester: Wiley.
 

--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -428,3 +428,20 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Parens-varianten omfattar endast `+46`/`0046`, inte domestikt `0` (FP-risk + inte i verkligt bruk). SSOT 4.2 uppdaterad i samma session.
 **Öppet/Nästa steg:** Kvarvarande 2 FP på telefon (IBAN-fragment som matchar telefon-regex) hör till issue #39. Commit sker efter granskning (ingen commit i denna session).
 
+#### Session 2026-04-18 - Cursor-agent (Opus)
+
+**Iteration:** 1 / v0.1.1
+**Mål:** Lösa issue #39 - dokumentera IBAN-telefon-FP som känd begränsning i SSOT.
+
+**Ändrade filer:**
+- `docs/arkitektur.md` - nytt avsnitt 14 "Kända begränsningar (iteration 1)" infört före Referenser; "Referenser" renumrerad från 14 till 15.
+- `docs/iteration_1_demoforberedelse.md` - denna sessionspost.
+
+**Gjort:**
+- Lagt in ~24 raders prosa som beskriver fenomenet (telefon-regex matchar siffersekvenser inom IBAN-fynd), de två konkreta FP-exemplen verbatim (`"0555 5555 55"` inom `SE96 5000 0000 0555 5555 55` och `"05 1234 5678"` inom `SE05 1234 5678 9012 3456 78`), grundorsak på aggregator-nivå, motivering till att inte åtgärda i iteration 1 (koppling till designprincip 3 och intressentdiskussion), samt planerad containment-regel för iteration 2.
+- Renumrerat "Referenser" från 14 till 15.
+- Ingen kodfil rörd; verifierat med `git status` att endast `docs/arkitektur.md` och `docs/iteration_1_demoforberedelse.md` är ändrade.
+
+**Beslut fattade:** Placering som nytt avsnitt 14 före Referenser valdes framför renumrering av sektion 12-13 eller underrubrik under Iterationsplan, efter granskning i Plan Mode. Terminologi "tar bort"/"bortfiltrerat" valdes framför anglicismen "droppa" för att matcha SSOT-prosans ton ("reducera fyndmängden", "aktiv reduktionsregel").
+**Öppet/Nästa steg:** Issue #39 klar för commit efter granskning. Nästa: issue #40 (SpaCy EntityLayer i `layers/entity/entity_layer.py`). Commit sker efter granskning (ingen commit i denna session).
+


### PR DESCRIPTION
## Summary
- Resolves issue #39 by documenting the IBAN ↔ telefon overlap as a known limitation in SSOT (`docs/arkitektur.md`), adding a new section 14 "Kända begränsningar (iteration 1)" before Referenser (which is renumbered to 15).
- The new section describes the phenomenon (telefon-regex matches digit sequences inside IBAN findings), lists the two concrete FP examples verbatim, explains the aggregator-level root cause, motivates why it is not fixed in iteration 1, and notes the planned containment rule for iteration 2.
- Adds a session log entry to `docs/iteration_1_demoforberedelse.md`.

## Test plan
- [x] No code touched; only documentation.
- [x] Merged `main` into the branch and resolved the session-log conflict by preserving both entries and ordering them by issue number (#37, #38, #39, #42).
- [x] `git diff --check` clean; no conflict markers remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with a new section documenting known limitations and issues identified during iteration 1, including specific false positive scenarios.
  * Reorganized session logs and restructured the documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->