### PR TITLE
docs: remove stray blank line above Miljösetup heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A layered Python pipeline for automatic GDPR text classification.
 
-
 ### Miljösetup
 
 ```bash


### PR DESCRIPTION
Collapses the double blank line between the project tagline and the first
section heading into a single blank line for consistent spacing.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated README formatting with minor whitespace adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->