### PR TITLE
docs: update iteration 1 demo preparation with new SpaCy-based entity layer implementation

### DIFF
--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -487,3 +487,33 @@ Lägg till en ny post längst ner. Använd följande mall:
 
 **Beslut fattade:** ORG mappas till `Category.ORGANISATION = "context.organisation"` (nytt `context.*`-prefix för kontextsignaler som inte i sig är art 4-data). Full motivering går till repots Loggbok i separat session; SSOT avsnitt 3.3, 5 och 12 och denna session räcker för implementationsprompten.
 **Öppet/Nästa steg:** Pre-existerande drift mellan `core/category.py` (`POSTORT`, `POSTNUMMER`) och SSOT avsnitt 3.3 rörs inte här - egen issue. Implementationsprompt för sammanslagna #40 skrivs mot denna synkade SSOT.
+
+#### Session 2026-04-18 - Cursor-agent (Opus)
+
+**Iteration:** 1 / v0.1.1
+**Mål:** Implementera issue #40 (stänger #41) - SpaCy-baserad EntityLayer med PER/LOC/ORG-mappning och ny `Category.ORGANISATION = "context.organisation"`.
+
+**Ändrade filer:**
+- `gdpr_classifier/core/category.py` - ny grupp `# Kontextsignaler: inte art 4-data i sig, bidrar till klassificering i kombination` med `ORGANISATION = "context.organisation"` insatt mellan art 9-blocket och `KONTEXTUELLT_KANSLIG`. Ingen befintlig medlem flyttad.
+- `gdpr_classifier/layers/entity/entity_layer.py` - stub ersatt med SpaCy-implementation: laddar `sv_core_news_lg` i `__init__`, `_label_map` mappar `PER→Category.NAMN/entity.spacy_PER`, `LOC→Category.ADRESS/entity.spacy_LOC`, `ORG→Category.ORGANISATION/entity.spacy_ORG`. `confidence=0.8` hårdkodad, `metadata={"ner_label": ent.label_}`. Okända labels hoppas över.
+- `docs/iteration_1_demoforberedelse.md` - denna sessionspost.
+
+**Gjort:**
+- Installerat spaCy 3.8.14 i `.venv` via `pip install -e .[nlp]`. `sv_core_news_lg` 3.8.0 var redan installerad i miljön - verifierat med `spacy.load('sv_core_news_lg')`. Ingen modell-download behövdes.
+- `pyproject.toml`-verifiering: `spacy>=3.7` fanns redan i `nlp` och `all` dependency-grupperna - ingen ändring behövdes.
+- `evaluation/dataset/loader.py`-verifiering: loadern använder `Category(finding_data["category"])` dynamiskt (rad 36), så Del 1 räcker och ingen hardkodad allow-list finns - ingen ändring behövdes.
+- Kört `.venv\Scripts\python.exe run_evaluation.py`.
+  - Totalt före (iteration 1-baseline, enbart pattern-lagret): `TP=44, FP=2, FN=0`, precision 95.65%, recall 100%, F1 97.78%.
+  - Totalt efter: `TP=44, FP=4, FN=0`, precision 91.67%, recall 100%, F1 95.65%. Recall oförändrad 100% för alla `article4.*`-kategorier.
+  - Per lager: `pattern: TP=44, FP=2` (oförändrat), `entity: TP=0, FP=2` (nytt lager aktiverat).
+  - Per kategori: `article4.adress` nu synlig med `TP=0, FP=2` (LOC-fynd mappade hit utan ground-truth); övriga art4-kategorier oförändrade.
+  - Totalt **2 NER-fynd** producerade mot nuvarande testdata, båda LOC:
+    - `[entity.spacy_LOC] "9001010009"` i `"Kunden (9001010009) ringde in."` - modellen flaggade personnummer-strängen som LOC (feldetektion som motiverar pattern-lagrets prioritet vid överlapp).
+    - `[entity.spacy_LOC] "Stockholm"` i `"Namn: Anna Andersson\nPersonnummer: 19801010-0009\nOrt: Stockholm"` - korrekt LOC-detektion.
+  - **0 PER-fynd** och **0 ORG-fynd** på nuvarande testdata trots att texterna innehåller namn (`Anna Andersson`, `Erik Eriksson`, `Maja Maj`, `Kalle`, `olof.olofsson`) och organisationen `Nordea`. Modellen plockade inte upp dem i de kontexter de förekommer (chattmeddelanden/mailfragment). Detta är utgångspunkten för Johannas #45-47 - testdata behöver entiteter i kontexter där modellen faktiskt triggar.
+- Kört `.venv\Scripts\python.exe -m pytest tests/integration/test_end_to_end.py -s`: 1 passed.
+- `ReadLints` på `core/category.py` och `layers/entity/entity_layer.py`: rent.
+- `git status` visar exakt tre förväntade ändrade filer: `gdpr_classifier/core/category.py`, `gdpr_classifier/layers/entity/entity_layer.py`, `docs/iteration_1_demoforberedelse.md`.
+
+**Beslut fattade:** DoD-raden "Total recall/precision ska inte regressera mot iteration 1-baseline" i originalprompten ersattes efter Plan Mode-granskning av två sanningsenliga krav: (a) recall för `article4.*`-kategorier ska inte regressera (uppfyllt, 100% per kategori), och (b) nya FP från NER-lagret rapporteras med antal och exempel (2 LOC-FP, se ovan). Totalprecision regresserade från 95.65% till 91.67% - förväntad arkitektonisk effekt av att NER-lagret aktiveras innan datasetet har NER-ground-truth. Effekten upphör när #45-47 levererar PER/LOC/ORG-labels. Kategoriplacering i `core/category.py` enligt Alternativ A: `ORGANISATION` och `KONTEXTUELLT_KANSLIG` behålls i två separata kommentargrupper (speglar SSOT och Plan Mode-beslutet att deras semantik är olika trots gemensamt `context.*`-prefix).
+**Öppet/Nästa steg:** Johannas #45-47 (NER-testdata med ground-truth PER/LOC/ORG) är naturlig verifiering av EntityLayers recall. Eventuell evaluation-filtrering av `context.*`-fynd hör till separat issue. LOC-feldetektion av `9001010009` som plats-namn kan bli en not i avsnitt 14 (Kända begränsningar) om den kvarstår efter #45-47. Commit sker efter granskning (ingen commit i denna session).

--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -388,7 +388,7 @@ Lägg till en ny post längst ner. Använd följande mall:
 
 ### Poster
 
-#### Session 2026-04-18 - Cursor-agent (Opus)
+#### Session 2026-04-18 - Cursor-agent (Opus) (issue #37)
 
 **Iteration:** 1 / v0.1.1
 **Mål:** Lösa issue #37 - utöka email-regex för IDN-domäner med svenska tecken (å, ä, ö).
@@ -407,7 +407,7 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Behåller `[a-zA-Z]{2,}` i TLD-delen; punycode/xn-- och IDN-TLD ligger utanför iteration 1:s scope (SSOT 4.2).
 **Öppet/Nästa steg:** Kvarvarande FN/FP ligger i `article4.telefonnummer` (recall 90%, precision 81.82%) - hör till andra issues. Unit-tester för email-edge cases vid behov i senare issue. Commit sker efter granskning (ingen commit i denna session).
 
-#### Session 2026-04-18 - Cursor-agent (Opus)
+#### Session 2026-04-18 - Cursor-agent (Opus) (issue #38)
 
 **Iteration:** 1 / v0.1.1
 **Mål:** Lösa issue #38 - utöka telefon-regex så att `+46`/`0046` får omges av balanserade parenteser (t.ex. `(+46)70 999 88 77`).
@@ -426,7 +426,7 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Parens-varianten omfattar endast `+46`/`0046`, inte domestikt `0` (FP-risk + inte i verkligt bruk). SSOT 4.2 uppdaterad i samma session.
 **Öppet/Nästa steg:** Kvarvarande 2 FP på telefon (IBAN-fragment som matchar telefon-regex) hör till issue #39. Commit sker efter granskning (ingen commit i denna session).
 
-#### Session 2026-04-18 - Cursor-agent (Opus)
+#### Session 2026-04-18 - Cursor-agent (Opus) (issue #39)
 
 **Iteration:** 1 / v0.1.1
 **Mål:** Lösa issue #39 - dokumentera IBAN-telefon-FP som känd begränsning i SSOT.
@@ -467,7 +467,7 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Utvärderingen körs globalt en gång vid uppstart (inte per toggle-klick) för responsivt UI.
 **Öppet/Nästa steg:** Issue #43 (fritext-analys med markeringar).
 
-#### Session 2026-04-18 - Cursor-agent (Opus)
+#### Session 2026-04-18 - Cursor-agent (Opus) (issue #40+#41 docs-merge)
 
 **Iteration:** 1 / v0.1.1
 **Mål:** Dokumentations-merge av issue #40+#41 och kategori-beslut C (ORG som `context.organisation`) i SSOT och demoforberedelse.md innan implementationsprompten.
@@ -488,7 +488,7 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** ORG mappas till `Category.ORGANISATION = "context.organisation"` (nytt `context.*`-prefix för kontextsignaler som inte i sig är art 4-data). Full motivering går till repots Loggbok i separat session; SSOT avsnitt 3.3, 5 och 12 och denna session räcker för implementationsprompten.
 **Öppet/Nästa steg:** Pre-existerande drift mellan `core/category.py` (`POSTORT`, `POSTNUMMER`) och SSOT avsnitt 3.3 rörs inte här - egen issue. Implementationsprompt för sammanslagna #40 skrivs mot denna synkade SSOT.
 
-#### Session 2026-04-18 - Cursor-agent (Opus)
+#### Session 2026-04-18 - Cursor-agent (Opus) (issue #40 impl)
 
 **Iteration:** 1 / v0.1.1
 **Mål:** Implementera issue #40 (stänger #41) - SpaCy-baserad EntityLayer med PER/LOC/ORG-mappning och ny `Category.ORGANISATION = "context.organisation"`.

--- a/gdpr_classifier/core/category.py
+++ b/gdpr_classifier/core/category.py
@@ -26,5 +26,8 @@ class Category(str, Enum):
     BIOMETRISK_DATA = "article9.biometrisk_data"
     SEXUELL_LAGGNING = "article9.sexuell_laggning"
 
+    # Kontextsignaler: inte art 4-data i sig, bidrar till klassificering i kombination
+    ORGANISATION = "context.organisation"
+
     # Kontextuellt känsligt data
     KONTEXTUELLT_KANSLIG = "context.identifierbar"

--- a/gdpr_classifier/layers/entity/entity_layer.py
+++ b/gdpr_classifier/layers/entity/entity_layer.py
@@ -1,22 +1,45 @@
 """EntityLayer implementation.
 
-Stub for iteration 1. The EntityLayer will later wrap a named entity
-recognition model (SpaCy or KB-BERT) to produce findings for person
-names, locations, and organizations (see ``docs/arkitektur.md`` section
-5). For now, ``detect`` returns an empty list so the pipeline can
-instantiate and run all three layers without error already in
-iteration 1.
+SpaCy-baserad NER-detektion som mappar PER -> Category.NAMN,
+LOC -> Category.ADRESS och ORG -> Category.ORGANISATION. Se
+``docs/arkitektur.md`` avsnitt 5 för kategori-mapping och
+source-taggar. Modellen ``sv_core_news_lg`` laddas vid konstruktion.
 """
 
 from __future__ import annotations
 
-from gdpr_classifier.core import Finding
+import spacy
+
+from gdpr_classifier.core import Category, Finding
 
 
 class EntityLayer:
+    def __init__(self, model_name: str = "sv_core_news_lg"):
+        self._nlp = spacy.load(model_name)
+        self._label_map = {
+            "PER": (Category.NAMN, "entity.spacy_PER"),
+            "LOC": (Category.ADRESS, "entity.spacy_LOC"),
+            "ORG": (Category.ORGANISATION, "entity.spacy_ORG"),
+        }
+
     @property
     def name(self) -> str:
         return "entity"
 
     def detect(self, text: str) -> list[Finding]:
-        return []
+        findings: list[Finding] = []
+        doc = self._nlp(text)
+        for ent in doc.ents:
+            if ent.label_ not in self._label_map:
+                continue
+            category, source = self._label_map[ent.label_]
+            findings.append(Finding(
+                category=category,
+                start=ent.start_char,
+                end=ent.end_char,
+                text_span=ent.text,
+                confidence=0.8,
+                source=source,
+                metadata={"ner_label": ent.label_},
+            ))
+        return findings


### PR DESCRIPTION
- Added a new session entry for the implementation of issue #40, detailing the integration of a SpaCy-based EntityLayer for mapping entities (PER, LOC, ORG) to their respective categories.
- Documented changes in `gdpr_classifier/core/category.py` to include `Category.ORGANISATION = "context.organisation"` as a context signal.
- Updated `gdpr_classifier/layers/entity/entity_layer.py` to replace the stub with a functional implementation that utilizes SpaCy for entity detection and classification.
- Verified installation of SpaCy and confirmed no changes were needed in dependency management.
- Recorded evaluation results showing the impact of the new entity layer on precision and recall metrics, highlighting areas for future improvement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity detection now operational using a SpaCy-backed NER pipeline
  * Detects Person, Location and Organization entities; adds an Organization category
  * Detected entities include confidence scores and source/label metadata

* **Documentation**
  * Added session notes with implementation details, evaluation deltas vs. baseline, and observed error profile; next validation steps recorded
<!-- end of auto-generated comment: release notes by coderabbit.ai -->