### PR TITLE
feat: implement free-text analysis tab with highlighted findings and …

### DIFF
--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -9,15 +9,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from dash import Input, Output, callback, dash_table, dcc, html
+from collections import defaultdict
+
+from dash import Input, Output, State, callback, dash_table, dcc, html
 
 from evaluation.dataset.loader import load_dataset
 from evaluation.report import Report
 from evaluation.runner import run_evaluation
 from gdpr_classifier import Aggregator, Pipeline
+from gdpr_classifier.core.classification import Classification
+from gdpr_classifier.core.finding import Finding
 from gdpr_classifier.layers.context import ContextLayer
 from gdpr_classifier.layers.entity import EntityLayer
 from gdpr_classifier.layers.pattern import PatternLayer
+from demo.layout import freetext_tab_layout
 
 _LOG = logging.getLogger(__name__)
 
@@ -281,6 +286,187 @@ def _evaluation_unavailable() -> html.Div:
 
 
 # ---------------------------------------------------------------------------
+# Freetext helpers (Issue #43 / #44)
+# ---------------------------------------------------------------------------
+
+_SOURCE_COLORS: dict[str, str] = {
+    "pattern": "orange",
+    "entity": "#add8e6",
+}
+
+
+def _resolve_overlaps(findings: list[Finding]) -> list[Finding]:
+    """Return a non-overlapping subset of findings, preferring highest confidence."""
+    if not findings:
+        return []
+    sorted_findings = sorted(findings, key=lambda f: (f.start, -f.confidence))
+    clusters: list[list[Finding]] = []
+    current_cluster: list[Finding] = [sorted_findings[0]]
+    cluster_end = sorted_findings[0].end
+    for f in sorted_findings[1:]:
+        if f.start < cluster_end:
+            current_cluster.append(f)
+            cluster_end = max(cluster_end, f.end)
+        else:
+            clusters.append(current_cluster)
+            current_cluster = [f]
+            cluster_end = f.end
+    clusters.append(current_cluster)
+    return [max(cluster, key=lambda f: (f.confidence, -f.start)) for cluster in clusters]
+
+
+def build_highlighted_text(text: str, findings: list[Finding]) -> list:
+    """Build a list of html.Span components with colour-coded, annotated findings."""
+    winners = _resolve_overlaps(findings)
+    winners.sort(key=lambda f: f.start)
+    spans: list = []
+    cursor = 0
+    for f in winners:
+        if cursor < f.start:
+            spans.append(html.Span(text[cursor : f.start]))
+        layer = f.source.split(".")[0]
+        bg = _SOURCE_COLORS.get(layer, "#e0e0e0")
+        tooltip = (
+            f"Kategori: {f.category.value}, "
+            f"Källa: {f.source}, "
+            f"Konfidens: {f.confidence:.0%}"
+        )
+        spans.append(
+            html.Span(
+                text[f.start : f.end],
+                title=tooltip,
+                style={
+                    "backgroundColor": bg,
+                    "borderRadius": "3px",
+                    "padding": "1px 2px",
+                    "cursor": "help",
+                },
+            )
+        )
+        cursor = f.end
+    if cursor < len(text):
+        spans.append(html.Span(text[cursor:]))
+    return spans
+
+
+def build_summary(classification: Classification) -> html.Div:
+    """Build a summary panel from a Classification result."""
+    level = classification.sensitivity.value.upper()
+    level_colors = {
+        "NONE": "#27ae60",
+        "LOW": "#f39c12",
+        "MEDIUM": "#e67e22",
+        "HIGH": "#e74c3c",
+    }
+    level_bg = level_colors.get(level, "#95a5a6")
+
+    per_category: dict[str, int] = defaultdict(int)
+    per_layer: dict[str, int] = defaultdict(int)
+    for f in classification.findings:
+        per_category[f.category.value] += 1
+        per_layer[f.source.split(".")[0]] += 1
+
+    category_rows = [
+        html.Tr([html.Td(cat), html.Td(str(count))])
+        for cat, count in sorted(per_category.items())
+    ]
+    layer_rows = [
+        html.Tr([html.Td(layer), html.Td(str(count))])
+        for layer, count in sorted(per_layer.items())
+    ]
+    table_style = {"borderCollapse": "collapse", "marginTop": "8px", "width": "auto"}
+    cell_style = {"border": "1px solid #ccc", "padding": "4px 12px"}
+
+    return html.Div(
+        [
+            html.Hr(),
+            html.H3("Sammanfattning", style={"marginBottom": "8px"}),
+            html.Div(
+                f"Känslighetsnivå: {level}",
+                style={
+                    "display": "inline-block",
+                    "backgroundColor": level_bg,
+                    "color": "white",
+                    "fontWeight": "bold",
+                    "padding": "4px 14px",
+                    "borderRadius": "4px",
+                    "marginBottom": "16px",
+                },
+            ),
+            html.Div(
+                [
+                    html.Div(
+                        [
+                            html.Strong("Fynd per GDPR-kategori"),
+                            html.Table(
+                                [
+                                    html.Thead(
+                                        html.Tr(
+                                            [
+                                                html.Th("Kategori", style=cell_style),
+                                                html.Th("Antal", style=cell_style),
+                                            ]
+                                        )
+                                    ),
+                                    html.Tbody(
+                                        [
+                                            html.Tr(
+                                                [
+                                                    html.Td(cat, style=cell_style),
+                                                    html.Td(str(cnt), style=cell_style),
+                                                ]
+                                            )
+                                            for cat, cnt in sorted(per_category.items())
+                                        ]
+                                    ),
+                                ],
+                                style=table_style,
+                            )
+                            if category_rows
+                            else html.P("Inga fynd."),
+                        ],
+                        style={"marginRight": "40px", "display": "inline-block", "verticalAlign": "top"},
+                    ),
+                    html.Div(
+                        [
+                            html.Strong("Fynd per lager"),
+                            html.Table(
+                                [
+                                    html.Thead(
+                                        html.Tr(
+                                            [
+                                                html.Th("Lager", style=cell_style),
+                                                html.Th("Antal", style=cell_style),
+                                            ]
+                                        )
+                                    ),
+                                    html.Tbody(
+                                        [
+                                            html.Tr(
+                                                [
+                                                    html.Td(layer, style=cell_style),
+                                                    html.Td(str(cnt), style=cell_style),
+                                                ]
+                                            )
+                                            for layer, cnt in sorted(per_layer.items())
+                                        ]
+                                    ),
+                                ],
+                                style=table_style,
+                            )
+                            if layer_rows
+                            else html.P("Inga fynd."),
+                        ],
+                        style={"display": "inline-block", "verticalAlign": "top"},
+                    ),
+                ]
+            ),
+        ],
+        style={"marginTop": "16px"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Callbacks
 # ---------------------------------------------------------------------------
 
@@ -319,13 +505,9 @@ def render_tab(tab: str) -> html.Div:
                 _make_table("testdata-table", _TESTDATA_COLUMNS, rows),
             ],
         )
-    # Stub for issue #43
-    return html.Div(
-        [
-            html.H2("Fritext-analys"),
-            html.P("Denna vy implementeras i Issue #43."),
-        ],
-    )
+    if tab == "tab-freetext":
+        return freetext_tab_layout()
+    return html.Div()
 
 
 @callback(
@@ -371,3 +553,22 @@ def update_report(verbose_values: list[str]) -> list:
         )
 
     return children
+
+
+@callback(
+    Output("freetext-result", "children"),
+    Output("freetext-summary", "children"),
+    Input("analyze-button", "n_clicks"),
+    State("freetext-input", "value"),
+    prevent_initial_call=True,
+)
+def analyze_text(n_clicks: int, text: str | None) -> tuple:
+    """Run the pipeline on free text and render highlighted results with summary."""
+    if not text:
+        return [], []
+    pipeline = build_pipeline()
+    classification = pipeline.classify(text)
+    return (
+        build_highlighted_text(text, classification.findings),
+        build_summary(classification),
+    )

--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -377,13 +377,24 @@ def build_summary(classification: Classification) -> html.Div:
         per_layer[f.source.split(".")[0]] += 1
 
     category_rows = [
-        html.Tr([html.Td(cat), html.Td(str(count))])
+        html.Tr(
+            [
+                html.Td(cat, style=cell_style), 
+                html.Td(str(count), style=cell_style)
+                ]
+        )
         for cat, count in sorted(per_category.items())
     ]
     layer_rows = [
-        html.Tr([html.Td(layer), html.Td(str(count))])
+        html.Tr(
+            [
+                html.Td(layer, style=cell_style), 
+                html.Td(str(count), style=cell_style)
+            ]
+        )
         for layer, count in sorted(per_layer.items())
     ]
+
     table_style = {"borderCollapse": "collapse", "marginTop": "8px", "width": "auto"}
     cell_style = {"border": "1px solid #ccc", "padding": "4px 12px"}
 
@@ -418,17 +429,7 @@ def build_summary(classification: Classification) -> html.Div:
                                             ]
                                         )
                                     ),
-                                    html.Tbody(
-                                        [
-                                            html.Tr(
-                                                [
-                                                    html.Td(cat, style=cell_style),
-                                                    html.Td(str(cnt), style=cell_style),
-                                                ]
-                                            )
-                                            for cat, cnt in sorted(per_category.items())
-                                        ]
-                                    ),
+                                    html.Tbody(category_rows),
                                 ],
                                 style=table_style,
                             )
@@ -450,17 +451,7 @@ def build_summary(classification: Classification) -> html.Div:
                                             ]
                                         )
                                     ),
-                                    html.Tbody(
-                                        [
-                                            html.Tr(
-                                                [
-                                                    html.Td(layer, style=cell_style),
-                                                    html.Td(str(cnt), style=cell_style),
-                                                ]
-                                            )
-                                            for layer, cnt in sorted(per_layer.items())
-                                        ]
-                                    ),
+                                    html.Tbody(layer_rows),
                                 ],
                                 style=table_style,
                             )
@@ -581,10 +572,10 @@ def analyze_text(n_clicks: int, text: str | None) -> tuple:
     except Exception:
         _LOG.exception("Pipeline failed during freetext analysis")
         error_msg = html.Div(
-            "Analysen misslyckades – kontrollera serverloggen för detaljer.",
+            "Analysen misslyckades - kontrollera serverloggen för detaljer.",
             style={"color": "red"},
         )
-        return [], error_msg
+        return [error_msg], []
     return (
         build_highlighted_text(text, classification.findings),
         build_summary(classification),

--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -53,6 +53,16 @@ def build_pipeline() -> Pipeline:
     )
 
 
+_FREETEXT_PIPELINE: Pipeline | None = None
+
+
+def _get_freetext_pipeline() -> Pipeline:
+    global _FREETEXT_PIPELINE
+    if _FREETEXT_PIPELINE is None:
+        _FREETEXT_PIPELINE = build_pipeline()
+    return _FREETEXT_PIPELINE
+
+
 @dataclass(frozen=True)
 class EvaluationResult:
     """Container for demo evaluation output."""
@@ -566,8 +576,15 @@ def analyze_text(n_clicks: int, text: str | None) -> tuple:
     """Run the pipeline on free text and render highlighted results with summary."""
     if not text:
         return [], []
-    pipeline = build_pipeline()
-    classification = pipeline.classify(text)
+    try:
+        classification = _get_freetext_pipeline().classify(text)
+    except Exception:
+        _LOG.exception("Pipeline failed during freetext analysis")
+        error_msg = html.Div(
+            "Analysen misslyckades – kontrollera serverloggen för detaljer.",
+            style={"color": "red"},
+        )
+        return [], error_msg
     return (
         build_highlighted_text(text, classification.findings),
         build_summary(classification),

--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -54,12 +54,13 @@ def build_pipeline() -> Pipeline:
 
 
 _FREETEXT_PIPELINE: Pipeline | None = None
-
+_FREETEXT_PIPELINE_LOCK = threading.Lock()
 
 def _get_freetext_pipeline() -> Pipeline:
     global _FREETEXT_PIPELINE
-    if _FREETEXT_PIPELINE is None:
-        _FREETEXT_PIPELINE = build_pipeline()
+    with _FREETEXT_PIPELINE_LOCK:
+        if _FREETEXT_PIPELINE is None:
+            _FREETEXT_PIPELINE = build_pipeline()
     return _FREETEXT_PIPELINE
 
 

--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -376,6 +376,9 @@ def build_summary(classification: Classification) -> html.Div:
         per_category[f.category.value] += 1
         per_layer[f.source.split(".")[0]] += 1
 
+    table_style = {"borderCollapse": "collapse", "marginTop": "8px", "width": "auto"}
+    cell_style = {"border": "1px solid #ccc", "padding": "4px 12px"}
+
     category_rows = [
         html.Tr(
             [
@@ -394,9 +397,6 @@ def build_summary(classification: Classification) -> html.Div:
         )
         for layer, count in sorted(per_layer.items())
     ]
-
-    table_style = {"borderCollapse": "collapse", "marginTop": "8px", "width": "auto"}
-    cell_style = {"border": "1px solid #ccc", "padding": "4px 12px"}
 
     return html.Div(
         [

--- a/demo/layout.py
+++ b/demo/layout.py
@@ -10,6 +10,11 @@ def freetext_tab_layout() -> html.Div:
     return html.Div(
         [
             html.H2("Fritext-analys"),
+            html.Label(
+                "Text att analysera",
+                htmlFor="freetext-input",
+                style={"display": "block", "marginBottom": "6px"},
+            ),
             dcc.Textarea(
                 id="freetext-input",
                 placeholder="Skriv eller klistra in text här...",

--- a/demo/layout.py
+++ b/demo/layout.py
@@ -5,6 +5,49 @@ from __future__ import annotations
 from dash import dash_table, dcc, html
 
 
+def freetext_tab_layout() -> html.Div:
+    """Return the layout for the Fritext-analys tab (Issue #43/#44)."""
+    return html.Div(
+        [
+            html.H2("Fritext-analys"),
+            dcc.Textarea(
+                id="freetext-input",
+                placeholder="Skriv eller klistra in text här...",
+                style={
+                    "width": "100%",
+                    "height": "160px",
+                    "fontFamily": "monospace",
+                    "fontSize": "14px",
+                    "marginBottom": "12px",
+                    "boxSizing": "border-box",
+                },
+            ),
+            html.Button(
+                "Analysera",
+                id="analyze-button",
+                n_clicks=0,
+                style={
+                    "padding": "8px 20px",
+                    "fontSize": "14px",
+                    "cursor": "pointer",
+                    "marginBottom": "24px",
+                },
+            ),
+            html.Div(
+                id="freetext-result",
+                style={
+                    "fontFamily": "monospace",
+                    "fontSize": "15px",
+                    "lineHeight": "1.8",
+                    "whiteSpace": "pre-wrap",
+                    "marginBottom": "24px",
+                },
+            ),
+            html.Div(id="freetext-summary"),
+        ],
+    )
+
+
 def get_layout() -> html.Div:
     """Return the top-level Dash layout with three tabs: report, freetext, and testdata."""
     return html.Div(

--- a/docs/iteration_1_demoforberedelse.md
+++ b/docs/iteration_1_demoforberedelse.md
@@ -467,6 +467,26 @@ Lägg till en ny post längst ner. Använd följande mall:
 **Beslut fattade:** Utvärderingen körs globalt en gång vid uppstart (inte per toggle-klick) för responsivt UI.
 **Öppet/Nästa steg:** Issue #43 (fritext-analys med markeringar).
 
+#### Session 2026-04-18 – Claude Sonnet 4.6 (claude-code)
+
+**Iteration:** 1 / v0.1.1
+**Mål:** Implementera Issue #43 (Fritext-analys-flik) och Issue #44 (Spårbarhet via tooltips).
+
+**Ändrade filer:**
+- `demo/layout.py` – Ny hjälpfunktion `freetext_tab_layout()` med `dcc.Textarea`, "Analysera"-knapp, `freetext-result`-div och `freetext-summary`-div.
+- `demo/callbacks.py` – Ny `_resolve_overlaps()` (klusteralgoritm för överlappande fynd), `build_highlighted_text()` (färgkodade `html.Span` med `title`-tooltip), `build_summary()` (sammanfattningspanel med känslighetsnivå + fynd per kategori/lager), samt `analyze_text`-callback. Stub-gren i `render_tab` ersatt med anrop till `freetext_tab_layout()`.
+
+**Gjort:**
+- Implementerat klusterbaserad överlappslösning: fynd grupperas i intervallkluster; per kluster väljs vinnaren med högst konfidens. Garanterar att ingen teckenposition dupliceras.
+- Färgkodning via `style`-attribut: `pattern.*` → `orange`, `entity.*` → `#add8e6` (lightblue).
+- Tooltip via `title`-attribut: `"Kategori: ..., Källa: ..., Konfidens: ..."`.
+- Sammanfattningspanel visar känslighetsnivå (färgkodad badge), fynd per GDPR-kategori och fynd per lager i tabellformat.
+- Återanvänder befintlig `build_pipeline()` (PatternLayer + EntityLayer + ContextLayer + Aggregator).
+- Commit ej gjord (väntar på instruktion).
+
+**Beslut fattade:** Överlappslösning via klustergruppa + max-confidence-vinnare (inte greedy cursor), eftersom det hanterar fall där ett sent fynd med hög konfidens ska vinna över ett tidigt fynd med låg konfidens inom samma kluster. Layoutkomponenter returnas från `layout.py` (separation of concerns); callbacks importerar `freetext_tab_layout` därifrån.
+**Öppet/Nästa steg:** Manuell verifiering i webbläsaren. Commit efter granskning.
+
 #### Session 2026-04-18 - Cursor-agent (Opus)
 
 **Iteration:** 1 / v0.1.1


### PR DESCRIPTION
…traceability (Issue #43, #44)

- Add freetext_tab_layout() in demo/layout.py with textarea, button and result divs
- Add build_highlighted_text() with cluster-based overlap resolution (highest confidence wins per cluster), colour-coded spans (orange=pattern, lightblue=entity) and title-tooltip traceability
- Add build_summary() with sensitivity badge and per-category/per-layer tables
- Add analyze_text() callback wired to the full Pipeline (PatternLayer + EntityLayer + ContextLayer)
- Update render_tab() to serve the new layout instead of the stub
- Add agent session log entries for Issue #43 and #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a freetext analysis tab with a textarea, an "Analyze" button, and result + summary panels.
  * Analysis highlights detected spans with color-coding and per-item tooltips; summary shows sensitivity and counts by GDPR/category and source layer.
  * Overlap deconfliction ensures a single best match per overlapping region; analysis errors and empty input produce clear messages.

* **Documentation**
  * Added notes describing the freetext UI, behavior, and overlap-handling approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->