### PR TITLE
Add experimental version 6 of Article 9 prompts for GDPR classification

### DIFF
--- a/demo/snapshots/iteration_3_baseline_post_I4.json
+++ b/demo/snapshots/iteration_3_baseline_post_I4.json
@@ -1,0 +1,2233 @@
+{
+  "metadata": {
+    "generated_at": "2026-05-12T13:12:58.190389+00:00",
+    "model": "qwen2.5:7b-instruct",
+    "prompt_versions": {
+      "article9": "v6",
+      "combination": "v5"
+    },
+    "dataset": {
+      "total_texts": 159,
+      "iteration_1_texts": 80,
+      "article9_texts": 52,
+      "combination_texts": 27
+    },
+    "git_commit": "164a6fefd194704dfb3ecb2bf25632a1918a96a7",
+    "pipeline_layers": [
+      "pattern",
+      "entity",
+      "article9",
+      "combination"
+    ]
+  },
+  "report": {
+    "total": {
+      "tp": 213,
+      "fp": 99,
+      "fn": 20,
+      "recall": 0.9141630901287554,
+      "precision": 0.6826923076923077,
+      "f1": 0.781651376146789
+    },
+    "per_category": {
+      "context.kombination": {
+        "tp": 9,
+        "fp": 12,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.42857142857142855,
+        "f1": 0.6
+      },
+      "article9.politisk_asikt": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article9.biometrisk_data": {
+        "tp": 6,
+        "fp": 2,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.75,
+        "f1": 0.8571428571428571
+      },
+      "context.plats": {
+        "tp": 14,
+        "fp": 4,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.7777777777777778,
+        "f1": 0.8750000000000001
+      },
+      "article4.email": {
+        "tp": 19,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "context.organisation": {
+        "tp": 23,
+        "fp": 21,
+        "fn": 4,
+        "recall": 0.8518518518518519,
+        "precision": 0.5227272727272727,
+        "f1": 0.647887323943662
+      },
+      "article4.namn": {
+        "tp": 32,
+        "fp": 3,
+        "fn": 1,
+        "recall": 0.9696969696969697,
+        "precision": 0.9142857142857143,
+        "f1": 0.9411764705882354
+      },
+      "article9.fackmedlemskap": {
+        "tp": 5,
+        "fp": 0,
+        "fn": 1,
+        "recall": 0.8333333333333334,
+        "precision": 1.0,
+        "f1": 0.9090909090909091
+      },
+      "article9.halsodata": {
+        "tp": 7,
+        "fp": 5,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5833333333333334,
+        "f1": 0.7368421052631579
+      },
+      "article4.personnummer": {
+        "tp": 18,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article9.genetisk_data": {
+        "tp": 4,
+        "fp": 2,
+        "fn": 3,
+        "recall": 0.5714285714285714,
+        "precision": 0.6666666666666666,
+        "f1": 0.6153846153846153
+      },
+      "article4.adress": {
+        "tp": 15,
+        "fp": 27,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.35714285714285715,
+        "f1": 0.5263157894736842
+      },
+      "context.yrke": {
+        "tp": 16,
+        "fp": 18,
+        "fn": 6,
+        "recall": 0.7272727272727273,
+        "precision": 0.47058823529411764,
+        "f1": 0.5714285714285714
+      },
+      "article9.religios_overtygelse": {
+        "tp": 6,
+        "fp": 5,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5454545454545454,
+        "f1": 0.7058823529411764
+      },
+      "article4.telefonnummer": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article4.betalkort": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article4.iban": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 1,
+        "recall": 0.9090909090909091,
+        "precision": 1.0,
+        "f1": 0.9523809523809523
+      },
+      "article9.sexuell_laggning": {
+        "tp": 2,
+        "fp": 0,
+        "fn": 4,
+        "recall": 0.3333333333333333,
+        "precision": 1.0,
+        "f1": 0.5
+      }
+    },
+    "per_layer": {
+      "entity": {
+        "tp": 46,
+        "fp": 35,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5679012345679012,
+        "f1": 0.7244094488188977
+      },
+      "pattern": {
+        "tp": 68,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article9": {
+        "tp": 36,
+        "fp": 14,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.72,
+        "f1": 0.8372093023255813
+      },
+      "context": {
+        "tp": 63,
+        "fp": 50,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5575221238938053,
+        "f1": 0.7159090909090909
+      }
+    },
+    "samples": [
+      {
+        "text": "Hej, mitt personnummer är 850823-1233 och jag undrar över min faktura.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Här kommer uppgifterna du frågade efter: 198508231233. Återkoppla om något saknas.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Patienten är född 710214-5674 och har tidigare sökt för samma besvär.",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 38,
+            "end": 68,
+            "text_span": "tidigare sökt för samma besvär",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Kan du dubbelkolla sökanden som har pnr 19991201-9875 tack?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kunden (9001010009) ringde in.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärende gällande pers.nr 850823+1233, han är över 100 år nu.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mitt barns personnummer är 20101112-1116.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Bokning bekräftad för 550505-5557, välkommen!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Namn: Anna Andersson\nPersonnummer: 19801010-0009\nOrt: Stockholm",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Skicka paketet till den vars personnummer slutar på 1234, hela är 600606-1235.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Nås lättast på info@företaget.se under kontorstid.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Testar att maila till firstname.lastname@domain.co.uk för att se om det går fram.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Min nya mail är developer+test@gmail.com om ni behöver kontakta mig.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vänligen kontakta support@skola.edu för IT-frågor.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Automatiskt meddelande skickat från no-reply@system.net, svara ej.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Du kan ringa mig på 070-123 45 67 efter klockan fem.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontoret har växelnummer +46 8 123 456 78 ifall det är brådskande.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ring 031 12 34 56 för teknisk support.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Jag testar att nå dig på 0701234567 men får inget svar.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mina nummer är (+46)70 999 88 77 eller 08-11 22 33.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Betala in avgiften till vårt konto: SE41 3456 7890 1234 5678 90, så märker vi det som betalt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Min utlandsbetalning studsar, jag angav SE16888877776666555544, är det fel?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vänligen överför beloppet till IBAN: SE96 5000 0000 0555 5555 55, senast fredag.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kan vi använda SE49101010101010101010, för den återkommande transaktionen?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontouppgifter:\nBank: Nordea\nIBAN: SE29 1111 2222 3333 4444 55\nBIC: NDEADESS",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Supporten,\nJag har problem med min inloggning. Mitt personnummer är 850101-1236. Kan ni återkomma till anna.svensson@mail.se eller ringa på 070-123 45 67?\nMvh Anna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Transaktion misslyckad för användare med mail olof.olofsson@exempel.com. Pengarna skulle ha gått till IBAN SE05 1234 5678 9012 3456 78, men kontot verkar vara spärrat. Hans PNR 19900101-1239 är flaggat.",
+        "false_positives": [
+          {
+            "category": "article9.biometrisk_data",
+            "start": 173,
+            "end": 190,
+            "text_span": "PNR 19900101-1239",
+            "confidence": 0.9,
+            "source": "article9.biometrisk_data",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Gästlista uppdaterad: \n- Erik Eriksson, erik@test.se, 073-111 22 33\n- Maja Maj, maja.maj@test.se, +4673 444 55 66",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Abonnemanget för 850823-1233 är aktiverat. Faktura skickas till kalle@karlsson.com och vi har uppdaterat ert telefonnummer till 070 123 45 67. Automatiska dragningar sker via IBAN SE41 3456 7890 1234 5678 90.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej, vi ses imorgon på mötet kl 14:00. Tar med fika!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Servern kraschade med felkod 503 Service Unavailable vid försök att hämta index.html.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Projektet måste vara klart i slutet av kvartalet. Kan ni uppdatera Jira-boarden med veckans status?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Till lunch finns det pannkakor med sylt eller vegetarisk soppa.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Testar att posta ett systemmeddelande för att se om MQ-kön tar emot strängar på över 256 tecken som förväntat via API:et på /v1/messages.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Koden kompilerar inte lokalt. Får Cannot resolve symbol 'DataLoader'. Har någon annan samma problem på senaste main-branchen?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Observera att dörren till trapphus B kommer vara låst under helgen för underhållsarbete.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vilket datum kom vi överens om för lanseringen av version 2.0? Var det den femtonde i nästa månad?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "En bugg har upptäckts i hur layouten renderas på Safari om man har dark mode påslaget, texten blir svart på svart bakgrund.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det är dags för vår årliga kickoff. Ni hittar schemat i kalenderinbjudan. Väl mött!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Exception in thread 'main' java.lang.NullPointerException vid radering av cache. Töm minnet och försök starta om podden.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Visa: 4111 1111 1111 1111 dras imorgon.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Här är ett Mastercard: 5105105105105100 i löpande text.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kort Amex 3782-822463-10005 är spärrat.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det här kortet 4111 1111 1111 1112 borde faktiskt ignoreras.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Dubbelkolla min order, jag betalade med 4111111111111111 förut.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna Svensson, tack för att du hörde av dig angående ärendet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mötet den 14 mars leddes av Lars-Göran Berg och protokollfördes av Maria Lindqvist.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 48,
+            "end": 66,
+            "text_span": "protokollfördes av",
+            "confidence": 0.9,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 18,
+            "end": 27,
+            "text_span": "leddes av",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi har tagit emot en förfrågan från Erik Johansson gällande tjänsten.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt överenskommelse med Karin Holm ska leveransen ske nästa vecka.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Björn Petersson och Cecilia Norström deltog i workshopen om hållbarhet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Projektledare: Gunnar Strand. Ansvarig tekniker: Sofia Lund.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 13,
+            "text_span": "Projektledare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 30,
+            "end": 47,
+            "text_span": "Ansvarig tekniker",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Chattlogg: Hej, jag heter Maja Hellström och undrar om ni kan hjälpa mig.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "HR-notat: Anställd Per-Olof Lindberg påbörjar sin tjänst den första i månaden.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 10,
+            "end": 18,
+            "text_span": "Anställd",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 0,
+            "end": 8,
+            "text_span": "HR-notat",
+            "confidence": 0.85,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Undertecknad Therese Magnusson intygar att uppgifterna är korrekta.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt protokollet framförde Ingrid Karlsson synpunkter, vilket Fredrik Ek noterade.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 75,
+            "end": 83,
+            "text_span": "noterade",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Mötet hölls i Stockholm den tredje mars.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 14,
+            "end": 23,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Paketet levereras till Sveavägen 44 på fredag.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kundbesöket är inbokat i Göteborg nästa vecka.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 25,
+            "end": 33,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Tåget avgår från Malmö C kl. 08:15.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Lagret finns i Örebro och hanterar norra regionen.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 35,
+            "end": 49,
+            "text_span": "norra regionen",
+            "confidence": 0.95,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 15,
+            "end": 21,
+            "text_span": "Örebro",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Avtalet skrevs under av Volvo AB.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Skatteverket har begärt in kompletterande uppgifter.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi samarbetar med Acme Corp sedan 2018.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Fakturan gäller tjänster utförda åt Nordea Bank.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontraktet löper ut och Region Skåne har inte förlängt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontakta Anna Svensson på anna.svensson@foretag.se angående ärendet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Erik Johansson, 820415-3426, är bosatt i Göteborg.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Volvo AB har registrerat IBAN SE35 5000 0000 0549 1000 0003.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ring Karin Holm på 070-123 45 67 för mer info om projektet i Malmö.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 61,
+            "end": 66,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Skatteverket kontaktade Lars Berg (lars.berg@privat.se) gällande deklarationen.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 35,
+            "end": 54,
+            "text_span": "lars.berg@privat.se",
+            "confidence": 0.0,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej,\n\nJag heter Sofia Ekström och mitt personnummer är 930715-1002. Jag har ett ärende gällande min senaste faktura som inte stämmer. Ni kan nå mig på sofia.ekstrom@mail.se eller ringa 073-555 12 34.\n\nMed vänliga hälsningar,\nSofia Ekström",
+        "false_positives": [
+          {
+            "category": "article4.namn",
+            "start": 225,
+            "end": 238,
+            "text_span": "Sofia Ekström",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "HR-notat 2026-03-15: Nyanställd Marcus Lindgren, personnummer 880312-1006, börjar som systemutvecklare på Ericsson AB den 1 april. Han är bosatt i Linköping och ska arbeta från kontoret på Teknikvägen 8.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 86,
+            "end": 102,
+            "text_span": "systemutvecklare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 86,
+            "end": 202,
+            "text_span": "systemutvecklare på Ericsson AB den 1 april. Han är bosatt i Linköping och ska arbeta från kontoret på Teknikvägen 8",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av yrkesroll (systemutvecklare), specifik organisation (Ericsson AB) och specifik plats (Teknikvägen 8) ger tillräcklig identifierbarhet för en person med viss kunskap om den specifika organisationen och dess kontor.",
+              "validation_path": "reconstructed"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Ekonomirapport Q1 2026\n\nHandelsbanken har bekräftat att överföringen till leverantören Anna-Karin Bergström genomfördes den 12 mars. Beloppet krediterades IBAN SE90 8000 5555 4444 3333 2222. Vid frågor, kontakta ekonomiavdelningen på ekonomi@foretaget.se.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 14,
+            "text_span": "Ekonomirapport",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 234,
+            "end": 254,
+            "text_span": "ekonomi@foretaget.se",
+            "confidence": 0.0,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärende #4521 – Omtvistad transaktion\n\nKund: Henrik Sjöberg\nKortnummer: 4532 8901 2345 6785\nHenrik rapporterar en okänd debitering på 2 450 kr den 28 februari. Han nås enklast via telefon 070-888 99 11 eller på henrik.sjoberg@example.com. Ärendet eskaleras till bedrägerienheten.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 261,
+            "end": 277,
+            "text_span": "bedrägerienheten",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 38,
+            "end": 58,
+            "text_span": "Kund: Henrik Sjöberg",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 238,
+            "end": 278,
+            "text_span": "Ärendet eskaleras till bedrägerienheten.",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik kund (Henrik Sjöberg) och den specifika organisationen (bedrägerienheten) ger tillräcklig identifierbarhet för en person med viss kunskap om företagets interna struktur.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Protokoll från styrelsemöte 2026-04-10\n\nNärvarande: Eva Nilsson (ordförande), Karl Hedlund (ledamot) och Fatima Al-Hassan (sekreterare).\n\nMötet hölls i Göteborgs lokaler hos Sigma IT. Eva Nilsson öppnade mötet och noterade att samtliga ledamöter var närvarande. Nästa möte planeras till den 8 maj.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 40,
+            "end": 183,
+            "text_span": "Närvarande: Eva Nilsson (ordförande), Karl Hedlund (ledamot) och Fatima Al-Hassan (sekreterare).\n\nMötet hölls i Göteborgs lokaler hos Sigma IT.",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av specifik plats (Göteborgs lokaler hos Sigma IT) och en specifik organisation (Sigma IT) kombinerat med de individuella rollerna (ordförande, ledamot, sekreterare) ger tillräcklig identifierbarhet för individen.",
+              "validation_path": "normalized"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 152,
+            "end": 161,
+            "text_span": "Göteborgs",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.namn",
+            "start": 184,
+            "end": 195,
+            "text_span": "Eva Nilsson",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article4.namn",
+            "start": 105,
+            "end": 121,
+            "text_span": "Fatima Al-Hassan"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lena,\n\nJag skriver angående utbetalningen till Jonas Wikström. Hans personnummer är 760924-1000 och beloppet ska sättas in på kontot med IBAN SE84 1200 3456 7890 1234 5678.\n\nSwedbank har bekräftat att kontot är aktivt. Kan du verifiera uppgifterna och genomföra överföringen?\n\nTack på förhand,\nLena",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 178,
+            "end": 186,
+            "text_span": "Swedbank"
+          }
+        ]
+      },
+      {
+        "text": "Incidentrapport – IT-säkerhet 2026-04-22\n\nRapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67.\nIncidenten upptäcktes av Teknik AB:s driftteam i Uppsala. En obehörig inloggning registrerades från en extern IP-adress kl. 03:14. Åtkomsten spärrades omedelbart och ärendet har rapporterats till CERT-SE.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 42,
+            "end": 117,
+            "text_span": "Rapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67",
+            "confidence": 0.9,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 42,
+            "end": 175,
+            "text_span": "Rapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67.\nIncidenten upptäcktes av Teknik AB:s driftteam i Uppsala",
+            "confidence": 0.9,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av rapportörens fullständiga namn (Björn Axelsson) och organisationen med plats (Teknik AB:s driftteam i Uppsala) ger tillräcklig identifierbarhet för en person med viss kunskap om Teknik AB.",
+              "validation_path": "reconstructed"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Betalningsbekräftelse\n\nKund: Petra Forsberg, anställd vid SEB Kort AB.\nBetalning mottagen via kort 4012 8888 8888 8811 den 15 april 2026. Beloppet 12 500 kr har bokförts. Kvitto skickas till petra.forsberg@seb.se.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärendelogg – Socialförvaltningen Malmö kommun\n\nÄrende öppnat: 2026-02-20\nKlient: Amira Hassan, personnummer 950503-1006, boende Rosengård.\nKontaktuppgifter: 076-200 33 44.\n\nAnteckning: Klienten har begärt stödinsats enligt SoL kap. 4 §1. Handläggare tilldelad. Uppföljningsmöte planeras inom två veckor.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 33,
+            "end": 38,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 39,
+            "end": 45,
+            "text_span": "kommun",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 33,
+            "end": 45,
+            "text_span": "Malmö kommun"
+          }
+        ]
+      },
+      {
+        "text": "Faktura #2026-0891\n\nFrån: Nordström Consulting AB, Vasagatan 12, Stockholm\nTill: Oskar Blom, oskar.blom@kund.se\n\nBelopp: 45 000 kr exkl. moms.\nBetalning sker till IBAN SE69 3000 1234 5678 9012 3456 senast 2026-05-15.\n\nVid frågor, kontakta oss på faktura@nordstromconsulting.se.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 51,
+            "end": 60,
+            "text_span": "Vasagatan",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article4.iban",
+            "start": 168,
+            "end": 197,
+            "text_span": "SE69 3000 1234 5678 9012 3456"
+          }
+        ]
+      },
+      {
+        "text": "Hej Malin! Hoppas du mår bra efter semestern. Jag har en fråga angående din arbetsskada från förra sommaren. Har du fortfarande ont i knät? Det är viktigt att vi ser till att du får rätt stöd och rehabilitering för att kunna komma tillbaka till jobbet fullt ut.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lisa, jag hoppas du mår bättre! Jag tänkte bara höra om hur det gick med din reumatologbesök igår. Har läkaren sagt något mer om dina besvär? Hoppas att du får bra hjälp och snabb lindring.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Sofia, \n\nJag skrev till dig för att få en uppdatering på hur det går med din handledare. Jag vet att du har varit sjukskriven sedan förra veckan med magsjukan och jag vill bara kolla om allt är lugnt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, fick ett mail från Lars igår - han är inte på jobbet idag utan har ringt in sjuk. Han nämnde att han hade ont i magen sedan igår kväll och misstänker det kan vara matförgiftning. Hörde du någonting mer om det?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Sofia, \n\nJag vet att du är ledig idag men jag tänkte höra om hur det går med dig efter operationen. Jag hoppas allt läker bra och att du inte har ont.\n\nHälsningar,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan, snabb fråga om det politiska läget inför valet. Kanske vi kan diskutera vilka partier som verkar bäst för företaget och våra anställda? Jag själv lutar åt en mer liberala linje när det gäller ekonomisk politik. Vad tycker du?",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 117,
+            "end": 126,
+            "text_span": "företaget",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars! Kul att du deltar i den här diskussionen om framtidens arbetsmarknad. Jag såg att du är aktivt engagerad i Unga Socialdemokrater, det är imponerande! Vi har en spännande idé för ett nytt projekt som vi tror kan vara bra för unga arbetare. Vill du diskutera det mer på Zoom imorgon?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej! Har du sett att det är full fart på anmälan till den kristna ungdomsgruppen som håller till i kyrkan? Vi behöver nog fler ledare, vad säger du?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej! \n\nJag har precis fått en förfrågan från en kund, som heter Lars. Han vill beställa ett presentkort till sin dotter som firar sina 18-år. Han nämnde att hon är väldigt aktiv i den baptistförsamlingen på Södermalm och gärna skulle använda presentkortet till att köpa böcker om religion.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 184,
+            "end": 216,
+            "text_span": "baptistförsamlingen på Södermalm",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 265,
+            "end": 288,
+            "text_span": "köpa böcker om religion",
+            "confidence": 0.85,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 207,
+            "end": 216,
+            "text_span": "Södermalm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan, \n\nJag hoppas allt är bra! Vi har ett fackligt möte imorgon kl 10:00 i konferensrummet för att diskutera den nya arbetstidsmodellen. Det är viktigt att alla fackliga representanter från vår avdelning deltar, särskilt du som är skyddsombud för Unionen. \n\nMed vänlig hälsning,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 238,
+            "end": 261,
+            "text_span": "skyddsombud för Unionen",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (skyddsombud) och den namngivna organisationen (Unionen) gör individen identifierbar, eftersom det är ett unikt roll-organisation-par i arbetsmiljön.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, \n\nJag vill kolla med dig om den kommande fackföreningsmötet. Jag har hört att du är skyddsombud för Byggnads? Det skulle vara kul att höra mer om vad som diskuteras. ",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 88,
+            "end": 118,
+            "text_span": "du är skyddsombud för Byggnads",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (skyddsombud) och en specifik organisation (Byggnads) ger tillräcklig identifierbarhet i en realistisk kontext, eftersom det är ett unikt roll-organisation-par.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars!\n\nVi har ett möte imorgon kl 10:00 för att diskutera den nya avtalsrörelsen. Det är viktigt att alla fackföreningsmedlemmar deltar eftersom det rör löneförhandlingar och arbetstidsregler.\n\nHälsningar,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, hoppas du mår bra! \n\nJag tänkte fråga om det går att få in din biometriska data i vårt system. Vi använder fingeravtryck för autentisering och det skulle underlätta arbetet med åtkomst till vissa filer. Skicka gärna ett mail tillbaka när du har tid att diskutera detta.",
+        "false_positives": [
+          {
+            "category": "article9.biometrisk_data",
+            "start": 69,
+            "end": 89,
+            "text_span": "din biometriska data",
+            "confidence": 0.95,
+            "source": "article9.biometrisk_data",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, det var kul att träffas på lunch igår! Vi behöver bara göra ett litet justering i systemet för att du ska kunna logga in med ditt ansikte. Har du möjlighet att komma hit och testa det imorgon morse?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Jonas!\n\nJag har testat det nya säkerhetssystemet med ansiktsigenkänning. Det fungerade bra! Mina kollegor tyckte också att det var smidigt att logga in med ansiktet, de sa att det kändes mer futuristiskt än att använda fingeravtryck. \n\nVad tycker du om att vi implementerar detta på vårt kontor?\n\nMvh,\nSofia",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 101,
+            "end": 109,
+            "text_span": "kollegor",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, \n\nKan du hjälpa mig med det här? Vi har ett problem med vårt nya biometriska låssystem. Det verkar som att Lisa's ansiktssigenkänning inte fungerar korrekt. Hon har provat flera gånger men systemet accepterar inte hennes mätningar. Kan du kolla in det så fort som möjligt?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,  \n\nVi har ett problem med det nya biometriska låssystemet. Det verkar felaktigt identifiera vissa användare, till exempel registrerar det inte alltid Annas ansikte korrekt när hon försöker logga in. Kan du ta en titt på systemet och se om du hittar felet? \n\nMvh,\nJohan",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nJag vill berätta att jag har fått tillbaka resultatet från mina genetiska analyser. Det visade sig att jag har en högre risk för utveckla hjärtkärlsjukdomar än genomsnittet, men inget som är akut eller behöver någon omedelbar åtgärd. Vi kan diskutera det mer när du har tid. \n\nMvh,\nLisa",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 123,
+            "end": 184,
+            "text_span": "en högre risk för utveckla hjärtkärlsjukdomar än genomsnittet"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lena! Har du sett Anna på sjukhuset idag? Hon verkar lite låg i energi och berättade att hon nyligen gjorde en genetisk testning som visade att hon har en förhöjd risk för diabetes. Det är ju tråkigt, men hoppas det inte blir något allvarligt.",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 46,
+            "end": 74,
+            "text_span": "Hon verkar lite låg i energi",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Anna jobbade som genetisk rådgivare på ett privat företag. En klient, Lars, hade genomgått en DNA-analys och fick besked att han har en högre risk att utveckla Parkinsons sjukdom än genomsnittet. Anna förklarade för Lars att detta inte betyder att han automatiskt kommer att få sjukdomen, utan att det är ett resultat av hans genetiska profil. Hon rekommenderade honom att prata med sin läkare om riskerna och möjliga förebyggande åtgärder.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 39,
+            "end": 57,
+            "text_span": "ett privat företag",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "article9.genetisk_data",
+            "start": 91,
+            "end": 104,
+            "text_span": "en DNA-analys",
+            "confidence": 0.95,
+            "source": "article9.genetisk_data",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 17,
+            "end": 35,
+            "text_span": "genetisk rådgivare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "article9.halsodata",
+            "start": 125,
+            "end": 194,
+            "text_span": "han har en högre risk att utveckla Parkinsons sjukdom än genomsnittet",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 0,
+            "end": 57,
+            "text_span": "Anna jobbade som genetisk rådgivare på ett privat företag",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av yrkesroll (genetisk rådgivare) och specifik organisation (ett privat företag) ger tillräcklig identifierbarhet för en person med viss kunskap om den branschen.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 129,
+            "end": 194,
+            "text_span": "har en högre risk att utveckla Parkinsons sjukdom än genomsnittet"
+          }
+        ]
+      },
+      {
+        "text": "Hej Anna, hoppas du mår bra! Jag skrev för att höra om det genetiska testet som du beställde. Det visade sig att du har en predisponering för diabetes typ 2, men det betyder inte nödvändigtvis att du kommer att utveckla sjukdomen. Vi kan diskutera riskerna och vilka åtgärder du kan vidta för att minska din risk. Ring gärna om du vill prata mer om det.",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 59,
+            "end": 92,
+            "text_span": "genetiska testet som du beställde",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, hoppas du mår bra! Jag har fått ett mail från en kund som vill att vi ska analysera deras släktforskningsresultat. De nämner att de har hittat en genetisk koppling till en känd släkting med Down syndrom och är oroliga för att det kan vara något fel med deras egna barn. Vi behöver diskutera hur vi ska handskas med detta, eftersom det rör känslig information om deras familj.",
+        "false_positives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 94,
+            "end": 123,
+            "text_span": "deras släktforskningsresultat",
+            "confidence": 0.85,
+            "source": "article9.genetisk_data",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 200,
+            "end": 212,
+            "text_span": "Down syndrom"
+          }
+        ]
+      },
+      {
+        "text": "Hej Johan! Jag skrev bara för att höra hur det går med projektet. Har du hunnit diskutera designen med din pojkvän, som jag vet är superkunnig inom detta område?",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 131,
+            "end": 160,
+            "text_span": "superkunnig inom detta område",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars! Jag såg att du var med på Pride-paraden i Stockholm igår. Var det kul? Jag tänkte eventuellt gå nästa år. Det är ju så inspirerande att se alla människor som vågar visa sin kärlek och sitt stöd för varandra.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 52,
+            "end": 61,
+            "text_span": "Stockholm",
+            "confidence": 0.99,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 36,
+            "end": 49,
+            "text_span": "Pride-paraden",
+            "confidence": 0.95,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 52,
+            "end": 61,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 36,
+            "end": 49,
+            "text_span": "Pride-paraden"
+          }
+        ]
+      },
+      {
+        "text": "Hej Stefan, hoppas du har en bra dag! Har du koll på när vi ska ha det mötet med kunden från XYZ AB? Jag skickade ett mail om det igår men fick inget svar. Hör av dig när du får chansen!\n\nMvh,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 81,
+            "end": 99,
+            "text_span": "kunden från XYZ AB",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 93,
+            "end": 99,
+            "text_span": "XYZ AB",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan, \n\nKan du kolla om det är möjligt att få de nya brochuresna i tryck imorgon? Behövs dem för mötet med kunderna på tisdag. \n\nMår bra annars! \n\nMvh,\nErik",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, Har du koll på den nya designen för hemsidan? Det verkar som att det är några små buggar kvar. Kan vi snabbt hoppa på Teams imorgon för att gå igenom det?",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 128,
+            "end": 133,
+            "text_span": "Teams",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan! Kan du kolla igenom den här rapporten och ge mig feedback innan måndagens möte? \n\nMvh,\nJohanna\n\n[Bifogat: Rapport.docx]",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan, \n\nKan du kolla igenom den här presentationen och ge feedback innan mötet imorgon? \n\n//Linnea\n\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lisa, \n\nKan du kolla om den nya produktkatalogen är klar? Behöver den imorgon för att skicka till trycket. \n\nMvh,\nAnna\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla om den nya produktkatalogen är klar? Behöver den till lunchmötet med kunderna imorgon. \n\nMvh,\nJohan \n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nKan du kolla om det går att få igenom den nya fakturan från \"Teknisk Service AB\" till redovisningen? Det står på fakturan att de ska betalas senast den 15:e.  Hör gärna av dig när du gjort det!\n\nMvh,\nAnna\n",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 73,
+            "end": 91,
+            "text_span": "Teknisk Service AB",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,  \n\nHar du hunnit se den nya designen för broschyren? Kan du ge mig feedback innan måndagen så vi hinner ändra den om det behövs. \n\nMvh, \nLars\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla om det finns budget kvar för att köpa nya möbler till kontoret? Vi behöver definitivt uppdatera den här sofforiten! 😅  Hör gärna av dig när du har en stund. \n\nMvh,\nErik",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla igenom den nya produktkatalogen och ge feedback senast fredag? Har skickat den till din e-post. \n\nMvh,\nLars",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anders,\n\nHoppas du har haft en bra vecka! Kan du kolla in den nya designen för hemsidan? Jag skickade den till din mail igår. Låt mig veta vad du tycker!\n\nMvh,\nSara",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,\n\nTack för att du tog upp det på mötet igår. Jag håller helt med dig om att vi borde rösta nej till det nya förslaget om utökad kameraövervakning på arbetsplatsen. Det strider mot grundläggande integritetsprinciper.\n\nMvh,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nJag såg att du kandiderar för Vänsterpartiet i höstens val. Det är modigt! Jag vet att det inte alltid är enkelt att vara öppen med politiska engagemang på arbetsplatsen.\n\nMvh,\nKarin",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,\n\nJag hittade din insändare i Aftonbladet där du skriver att Sverigedemokraterna bör uteslutas från samtliga riksdagsutskott. Ska vi ta upp det på nästa personalmöte eller håller du det privat?\n\nMvh,\nStefan",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lena,\n\nEfter senaste styrelsemötet är det tydligt att Erik är en övertygad förespråkare för privatisering av sjukvården. Han argumenterade bestämt för att landstingen borde lägga ut mer på privata aktörer.\n\nMvh,\nMaria",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan,\n\nJag vill bara flagga att Fatima inte kan delta i fredagsmötet. Hon har bett om att få ledigt för fredagsbönen och det har vi självklart godkänt.\n\nMvh,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lisa,\n\nJag har fått in en förfrågan från Lars om att byta sina semesterdagar. Han vill ha ledigt under påskveckan eftersom han och hans familj brukar fira påsk i kyrkan med sina barn.\n\nMvh,\nJohan",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej!\n\nVi behöver uppdatera personalregistret. Ahmed har meddelat att han är aktiv i den lokala moskéförsamlingen och önskar att det noteras för att undvika mötesbokningar under ramadan.\n\nMvh,\nPersonalavdelningen",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 192,
+            "end": 211,
+            "text_span": "Personalavdelningen",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,\n\nKarin har berättat att hon numera är Jehovas vittne och därför inte längre kan delta i firandet av jul och midsommar på kontoret. Vi behöver tänka på hur vi hanterar det framöver.\n\nMvh,\nPer",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 131,
+            "end": 139,
+            "text_span": "kontoret",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 98,
+            "end": 127,
+            "text_span": "firandet av jul och midsommar",
+            "confidence": 0.88,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nLycka till på din vigsel imorgon! Hoppas dagen med Marcus blir allt ni har drömt om.\n\nVarma hälsningar,\nLena",
+        "false_positives": [
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 30,
+            "end": 36,
+            "text_span": "vigsel",
+            "confidence": 0.93,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 26,
+            "end": 69,
+            "text_span": "din vigsel imorgon! Hoppas dagen med Marcus"
+          }
+        ]
+      },
+      {
+        "text": "Hej Maria,\n\nJag ville höra om du kan ta över Annas arbetspass på torsdag. Hon behöver ledigt för att hämta sin flickvän på flygplatsen.\n\nMvh,\nStefan",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 123,
+            "end": 134,
+            "text_span": "flygplatsen",
+            "confidence": 0.95,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 111,
+            "end": 119,
+            "text_span": "flickvän",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 107,
+            "end": 119,
+            "text_span": "sin flickvän"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lars,\n\nJag har sett att Erik är ordförande i företagets HBTQ-nätverk och öppet homosexuell. Är det något vi bör ta hänsyn till vid kundmötena i Mellanöstern nästa kvartal?\n\nMvh,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 28,
+            "end": 72,
+            "text_span": "Erik är ordförande i företagets HBTQ-nätverk",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ordförande) och en specifik organisation (företagets HBTQ-nätverk) ger tillräcklig identifierbarhet, eftersom det är ett unikt nätverk inom ett företag. Detta kombinerat med Erik som personnamn skulle ge starkt identifierbarhet.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 148,
+            "end": 160,
+            "text_span": "Mellanöstern",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej!\n\nEtt förtydligande inför konferensen: Karin och hennes fru Lisa bor på samma rum under övernattningen. Bokningsavdelningen ska notera detta.\n\nMvh,\nAdministrationen",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 108,
+            "end": 127,
+            "text_span": "Bokningsavdelningen",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 53,
+            "end": 68,
+            "text_span": "hennes fru Lisa",
+            "confidence": 0.85,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 152,
+            "end": 168,
+            "text_span": "Administrationen",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 53,
+            "end": 68,
+            "text_span": "hennes fru Lisa"
+          }
+        ]
+      },
+      {
+        "text": "Hej Stefan,\n\nJag fick precis bekräftelse från IF Metall att du är registrerad som medlem hos dem. Det innebär att du omfattas av det kollektivavtal vi tecknat.\n\nMvh,\nHR",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 46,
+            "end": 55,
+            "text_span": "IF Metall",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          },
+          {
+            "category": "context.organisation",
+            "start": 166,
+            "end": 168,
+            "text_span": "HR",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.fackmedlemskap",
+            "start": 66,
+            "end": 96,
+            "text_span": "registrerad som medlem hos dem"
+          }
+        ]
+      },
+      {
+        "text": "Hej Anna,\n\nJag vill informera om att Maja har gått med i Lärarförbundet sedan förra månaden. Hon har bett om att få delta i deras utbildningsdagar den 12 mars.\n\nMvh,\nPer",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nFör att hantera löneförhandlingen korrekt behöver vi veta om Lars är medlem i Unionen eller Akademikerförbundet SSR. Han har tidigare nämnt att han betalar fackkontingent till Unionen.\n\nMvh,\nEkonomi",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 90,
+            "end": 97,
+            "text_span": "Unionen",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          },
+          {
+            "category": "context.organisation",
+            "start": 104,
+            "end": 127,
+            "text_span": "Akademikerförbundet SSR",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,\n\nVi har registrerat Saras röstavtryck i telefonisystemet så att hon kan autentisera sig vid inloggning. Systemet kräver att hon läser upp en kort fras vid varje inloggning.\n\nMvh,\nIT-avdelningen",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Förslagsgruppen bestod av VD för Hvitfeldtska gymnasiets musiklinje och professor emeritus vid Göteborgs universitet.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 95,
+            "end": 116,
+            "text_span": "Göteborgs universitet",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Rektor på Hvitfeldtska gymnasiets musiklinje har bett mig att kontakta läkare i Göteborg om akut tandvård för hennes dotter.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 80,
+            "end": 88,
+            "text_span": "Göteborg",
+            "confidence": 0.99,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article9.halsodata",
+            "start": 92,
+            "end": 105,
+            "text_span": "akut tandvård",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 80,
+            "end": 88,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Professor Lars Eriksson, rektor på Hvitfeldtska gymnasiets musiklinje, meddelade personalen att de förväntade sig ett ökat antal elever.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 9,
+            "text_span": "Professor",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "article4.namn",
+            "start": 10,
+            "end": 23,
+            "text_span": "Lars Eriksson",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "En legitimerad tandläkare vid Västra Götalandsregionens tandvårdscenter i Borås har rapporterat ett misstänkt fall av bakterielinfektion.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 30,
+            "end": 55,
+            "text_span": "Västra Götalandsregionens",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 74,
+            "end": 79,
+            "text_span": "Borås",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Sjuksköterskan på intensivvården vid Sahlgrenska Universitetssjukhuset i Göteborg tog emot patienten från Hallands sjukhus.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 73,
+            "end": 81,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 106,
+            "end": 114,
+            "text_span": "Hallands",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Förläggaren för den nya elbilen, Volvo Cars, har etablerat ett produktionscenter i Trollhättan. De anställda där arbetar som montörer och mekaniker med hög specialisering inom elbilsteknik.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 83,
+            "end": 94,
+            "text_span": "Trollhättan",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 125,
+            "end": 133,
+            "text_span": "montörer"
+          }
+        ]
+      },
+      {
+        "text": "Avdelningschefen på vårdcentralen i Karlskoga diskuterade med den nya sjuksköterskan om patientflödet.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 36,
+            "end": 45,
+            "text_span": "Karlskoga",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 70,
+            "end": 84,
+            "text_span": "sjuksköterskan"
+          },
+          {
+            "category": "context.organisation",
+            "start": 20,
+            "end": 45,
+            "text_span": "vårdcentralen i Karlskoga"
+          }
+        ]
+      },
+      {
+        "text": "Den nya enhetschefen som tillträdde i januari efter omorganisationen vid Sahlgrenska Universitetssjukhuset har redan introducerat ett nytt schemasystem för hela avdelningen.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Den första kvinnliga produktionschefen på Volvo Cars Skövde, som rekryterades från huvudkontoret förra hösten, kommer att tala på branschkonferensen i juni.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det nya lagret på industrivägen öppnar i morgon och de första anställda börjar sin utbildning. Den ansvariga förlogistikstrategen, som flyttat hit från huvudkontoret i Stockholm, har gett tydliga instruktioner om hur man ska hantera den höga arbetsbelastningen.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 168,
+            "end": 177,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 112,
+            "end": 129,
+            "text_span": "logistikstrategen"
+          }
+        ]
+      },
+      {
+        "text": "Under mötesdagen diskuterade projektledaren och den ekonomiska experten från huvudkontoret om de nya budgetplanerna för deras gemensamma projekt i Uppsala.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 77,
+            "end": 90,
+            "text_span": "huvudkontoret",
+            "confidence": 0.97,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 29,
+            "end": 154,
+            "text_span": "projektledaren och den ekonomiska experten från huvudkontoret om de nya budgetplanerna för deras gemensamma projekt i Uppsala",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av specifik yrkesroll (projektledare och ekonomisk expert) samt en specifik organisation (huvudkontoret) och plats (Uppsala) ger tillräcklig identifierbarhet för en person med viss kunskap om projektet.",
+              "validation_path": "reconstructed"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 147,
+            "end": 154,
+            "text_span": "Uppsala",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Han jobbade som projektledare på den kommunala vårdcentralen i Karlskrona under 2022. Han var inte nöjd med sin lön och började leta efter nya möjligheter.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 16,
+            "end": 73,
+            "text_span": "projektledare på den kommunala vårdcentralen i Karlskrona",
+            "confidence": 0.93,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (projektledare) och en specifik plats (den kommunala vårdcentralen i Karlskrona) ger tillräcklig identifierbarhet för den som har viss kännedom om det lokala samhället.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 63,
+            "end": 73,
+            "text_span": "Karlskrona",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 37,
+            "end": 60,
+            "text_span": "kommunala vårdcentralen"
+          }
+        ]
+      },
+      {
+        "text": "På mötet diskuterade vi med den nya ekonomichefen hur projektet skulle drivas framåt. Han har tidigare arbetat som konsult inom IT-sektorn, men är nu ansvarig för vår avdelning här på fabriken i Borås.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 184,
+            "end": 200,
+            "text_span": "fabriken i Borås",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 36,
+            "end": 200,
+            "text_span": "ekonomichefen hur projektet skulle drivas framåt. Han har tidigare arbetat som konsult inom IT-sektorn, men är nu ansvarig för vår avdelning här på fabriken i Borås",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ekonomichef) och en specifik plats (fabriken i Borås) ger tillräcklig identifierbarhet för den som har viss kännedom om organisationens struktur.",
+              "validation_path": "reconstructed"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Det var en anställd på receptionen som berättade att de nya systemen för bokning av mötesrum skulle bli tillgängliga i höst. Hon nämnde också att personalen på IT-avdelningen jobbade hårt med det, men att det fortfarande var lite oklart när exakt de skulle vara färdiga.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 160,
+            "end": 174,
+            "text_span": "IT-avdelningen",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 23,
+            "end": 34,
+            "text_span": "receptionen",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 11,
+            "end": 19,
+            "text_span": "anställd"
+          }
+        ]
+      },
+      {
+        "text": "Den automatiserade processen aktiverades klockan 14.37. En loggsändning registrerades med kodnamn 'Fjärilsdans'. Det följande skedet, 'Stjärnfall', väntas inledas inom de närmaste fem minuterna.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Systemet registrerar automatiskt alla förändringar i databasen. Varje uppdatering sparas med en timestamp för fullständig historik.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Protokollen för uppdatering av databasen kommer att ske vid två tillfällen per dag. Första gången sker klockan 07:00 och den andra klockan 15:00. Under perioden mellan dessa uppdateringar kan det uppstå små variationer i informationen.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "En ny regel för hantering av digitala filer implementeras den 15 november. Det innebär att alla dokument ska sparas i en centraliserad plats med automatiskt numreringssystem.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Automatiserad processen genomfördes enligt schema. Dataanalysen visade en ökning i volym under perioden, vilket påverkade systemhastigheten. Vidare utvärderades algoritmen för att minska energiförbrukning.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt protokoll från den senaste iterationen ska den optimerade modellen gå igenom en komplex serie testfall. Syftet är att säkerställa att algoritmen hanterar olika scenarier korrekt och utan fel.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Lagledningen på konferensen diskuterade vikten av att anställa fler medarbetare med erfarenhet inom dataanalys och digital marknadsföring för att möta framtidens utmaningar.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Att jobba som försäljningskonsult i Malmö kan vara utmanande, men också väldigt givande. Det är viktigt att ha god kundservice och ett starkt nätverk för att lyckas.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 36,
+            "end": 41,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 14,
+            "end": 33,
+            "text_span": "försäljningskonsult"
+          }
+        ]
+      },
+      {
+        "text": "På mötet diskuterade vi behovet av fler lärare inom den digitala utbildningen i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 80,
+            "end": 89,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Förra veckan deltog många lärare från Stockholm i konferensen om digitalisering inom skolan.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 38,
+            "end": 47,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "På mötet diskuterade vi hur många anställda som arbetade på kontoret i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 71,
+            "end": 80,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 34,
+            "end": 43,
+            "text_span": "anställda"
+          }
+        ]
+      },
+      {
+        "text": "Det är alltid roligt att träffa nya kollegor på konferenser. I år var många från banksektorn i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 95,
+            "end": 104,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi har fått många ansökningar om tjänster som ekonomichef i Malmö, men det var svårt att hitta rätt profil.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 46,
+            "end": 65,
+            "text_span": "ekonomichef i Malmö",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ekonomichef) och en specifik plats (Malmö) ger tillräcklig identifierbarhet för att skapa pusselbitseffekten, särskilt i en kontext där det finns många ansökningar.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 60,
+            "end": 65,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      }
+    ],
+    "per_mechanism": {
+      "high_via_article9": 41,
+      "medium_via_bypass": 16,
+      "medium_via_mechanism3": 0,
+      "low_count": 63,
+      "none_count": 39
+    }
+  }
+}

--- a/demo/snapshots/iteration_3_baseline_v5_reproduction.json
+++ b/demo/snapshots/iteration_3_baseline_v5_reproduction.json
@@ -1,0 +1,2179 @@
+{
+  "metadata": {
+    "generated_at": "2026-05-12T12:37:13.665703+00:00",
+    "model": "qwen2.5:7b-instruct",
+    "prompt_versions": {
+      "article9": "v5",
+      "combination": "v5"
+    },
+    "dataset": {
+      "total_texts": 159,
+      "iteration_1_texts": 80,
+      "article9_texts": 52,
+      "combination_texts": 27
+    },
+    "git_commit": "164a6fefd194704dfb3ecb2bf25632a1918a96a7",
+    "pipeline_layers": [
+      "pattern",
+      "entity",
+      "article9",
+      "combination"
+    ]
+  },
+  "report": {
+    "total": {
+      "tp": 214,
+      "fp": 93,
+      "fn": 19,
+      "recall": 0.9184549356223176,
+      "precision": 0.6970684039087948,
+      "f1": 0.7925925925925925
+    },
+    "per_category": {
+      "article9.biometrisk_data": {
+        "tp": 6,
+        "fp": 1,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.8571428571428571,
+        "f1": 0.923076923076923
+      },
+      "article4.personnummer": {
+        "tp": 18,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article4.email": {
+        "tp": 19,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article4.adress": {
+        "tp": 15,
+        "fp": 27,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.35714285714285715,
+        "f1": 0.5263157894736842
+      },
+      "article9.religios_overtygelse": {
+        "tp": 5,
+        "fp": 1,
+        "fn": 1,
+        "recall": 0.8333333333333334,
+        "precision": 0.8333333333333334,
+        "f1": 0.8333333333333334
+      },
+      "context.plats": {
+        "tp": 14,
+        "fp": 4,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.7777777777777778,
+        "f1": 0.8750000000000001
+      },
+      "article9.fackmedlemskap": {
+        "tp": 5,
+        "fp": 0,
+        "fn": 1,
+        "recall": 0.8333333333333334,
+        "precision": 1.0,
+        "f1": 0.9090909090909091
+      },
+      "context.yrke": {
+        "tp": 16,
+        "fp": 20,
+        "fn": 6,
+        "recall": 0.7272727272727273,
+        "precision": 0.4444444444444444,
+        "f1": 0.5517241379310345
+      },
+      "article9.sexuell_laggning": {
+        "tp": 4,
+        "fp": 0,
+        "fn": 2,
+        "recall": 0.6666666666666666,
+        "precision": 1.0,
+        "f1": 0.8
+      },
+      "article4.betalkort": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article4.telefonnummer": {
+        "tp": 15,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "context.kombination": {
+        "tp": 9,
+        "fp": 12,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.42857142857142855,
+        "f1": 0.6
+      },
+      "article4.iban": {
+        "tp": 10,
+        "fp": 0,
+        "fn": 1,
+        "recall": 0.9090909090909091,
+        "precision": 1.0,
+        "f1": 0.9523809523809523
+      },
+      "article9.halsodata": {
+        "tp": 6,
+        "fp": 4,
+        "fn": 1,
+        "recall": 0.8571428571428571,
+        "precision": 0.6,
+        "f1": 0.7058823529411764
+      },
+      "article9.etniskt_ursprung": {
+        "tp": 0,
+        "fp": 1,
+        "fn": 0,
+        "recall": 0.0,
+        "precision": 0.0,
+        "f1": 0.0
+      },
+      "article4.namn": {
+        "tp": 32,
+        "fp": 3,
+        "fn": 1,
+        "recall": 0.9696969696969697,
+        "precision": 0.9142857142857143,
+        "f1": 0.9411764705882354
+      },
+      "article9.genetisk_data": {
+        "tp": 5,
+        "fp": 0,
+        "fn": 2,
+        "recall": 0.7142857142857143,
+        "precision": 1.0,
+        "f1": 0.8333333333333333
+      },
+      "context.organisation": {
+        "tp": 23,
+        "fp": 20,
+        "fn": 4,
+        "recall": 0.8518518518518519,
+        "precision": 0.5348837209302325,
+        "f1": 0.6571428571428571
+      },
+      "article9.politisk_asikt": {
+        "tp": 6,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      }
+    },
+    "per_layer": {
+      "pattern": {
+        "tp": 68,
+        "fp": 0,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 1.0,
+        "f1": 1.0
+      },
+      "article9": {
+        "tp": 37,
+        "fp": 7,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.8409090909090909,
+        "f1": 0.9135802469135803
+      },
+      "context": {
+        "tp": 63,
+        "fp": 51,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5526315789473685,
+        "f1": 0.711864406779661
+      },
+      "entity": {
+        "tp": 46,
+        "fp": 35,
+        "fn": 0,
+        "recall": 1.0,
+        "precision": 0.5679012345679012,
+        "f1": 0.7244094488188977
+      }
+    },
+    "samples": [
+      {
+        "text": "Hej, mitt personnummer är 850823-1233 och jag undrar över min faktura.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Här kommer uppgifterna du frågade efter: 198508231233. Återkoppla om något saknas.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Patienten är född 710214-5674 och har tidigare sökt för samma besvär.",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 47,
+            "end": 68,
+            "text_span": "sökt för samma besvär",
+            "confidence": 0.95,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Kan du dubbelkolla sökanden som har pnr 19991201-9875 tack?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kunden (9001010009) ringde in.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärende gällande pers.nr 850823+1233, han är över 100 år nu.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mitt barns personnummer är 20101112-1116.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Bokning bekräftad för 550505-5557, välkommen!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Namn: Anna Andersson\nPersonnummer: 19801010-0009\nOrt: Stockholm",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Skicka paketet till den vars personnummer slutar på 1234, hela är 600606-1235.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Nås lättast på info@företaget.se under kontorstid.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Testar att maila till firstname.lastname@domain.co.uk för att se om det går fram.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Min nya mail är developer+test@gmail.com om ni behöver kontakta mig.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vänligen kontakta support@skola.edu för IT-frågor.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Automatiskt meddelande skickat från no-reply@system.net, svara ej.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Du kan ringa mig på 070-123 45 67 efter klockan fem.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontoret har växelnummer +46 8 123 456 78 ifall det är brådskande.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ring 031 12 34 56 för teknisk support.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Jag testar att nå dig på 0701234567 men får inget svar.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mina nummer är (+46)70 999 88 77 eller 08-11 22 33.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Betala in avgiften till vårt konto: SE41 3456 7890 1234 5678 90, så märker vi det som betalt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Min utlandsbetalning studsar, jag angav SE16888877776666555544, är det fel?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vänligen överför beloppet till IBAN: SE96 5000 0000 0555 5555 55, senast fredag.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kan vi använda SE49101010101010101010, för den återkommande transaktionen?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontouppgifter:\nBank: Nordea\nIBAN: SE29 1111 2222 3333 4444 55\nBIC: NDEADESS",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Supporten,\nJag har problem med min inloggning. Mitt personnummer är 850101-1236. Kan ni återkomma till anna.svensson@mail.se eller ringa på 070-123 45 67?\nMvh Anna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Transaktion misslyckad för användare med mail olof.olofsson@exempel.com. Pengarna skulle ha gått till IBAN SE05 1234 5678 9012 3456 78, men kontot verkar vara spärrat. Hans PNR 19900101-1239 är flaggat.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Gästlista uppdaterad: \n- Erik Eriksson, erik@test.se, 073-111 22 33\n- Maja Maj, maja.maj@test.se, +4673 444 55 66",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Abonnemanget för 850823-1233 är aktiverat. Faktura skickas till kalle@karlsson.com och vi har uppdaterat ert telefonnummer till 070 123 45 67. Automatiska dragningar sker via IBAN SE41 3456 7890 1234 5678 90.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej, vi ses imorgon på mötet kl 14:00. Tar med fika!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Servern kraschade med felkod 503 Service Unavailable vid försök att hämta index.html.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Projektet måste vara klart i slutet av kvartalet. Kan ni uppdatera Jira-boarden med veckans status?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Till lunch finns det pannkakor med sylt eller vegetarisk soppa.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Testar att posta ett systemmeddelande för att se om MQ-kön tar emot strängar på över 256 tecken som förväntat via API:et på /v1/messages.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Koden kompilerar inte lokalt. Får Cannot resolve symbol 'DataLoader'. Har någon annan samma problem på senaste main-branchen?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Observera att dörren till trapphus B kommer vara låst under helgen för underhållsarbete.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vilket datum kom vi överens om för lanseringen av version 2.0? Var det den femtonde i nästa månad?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "En bugg har upptäckts i hur layouten renderas på Safari om man har dark mode påslaget, texten blir svart på svart bakgrund.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det är dags för vår årliga kickoff. Ni hittar schemat i kalenderinbjudan. Väl mött!",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Exception in thread 'main' java.lang.NullPointerException vid radering av cache. Töm minnet och försök starta om podden.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Visa: 4111 1111 1111 1111 dras imorgon.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Här är ett Mastercard: 5105105105105100 i löpande text.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kort Amex 3782-822463-10005 är spärrat.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det här kortet 4111 1111 1111 1112 borde faktiskt ignoreras.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Dubbelkolla min order, jag betalade med 4111111111111111 förut.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna Svensson, tack för att du hörde av dig angående ärendet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Mötet den 14 mars leddes av Lars-Göran Berg och protokollfördes av Maria Lindqvist.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 48,
+            "end": 66,
+            "text_span": "protokollfördes av",
+            "confidence": 0.9,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 18,
+            "end": 27,
+            "text_span": "leddes av",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi har tagit emot en förfrågan från Erik Johansson gällande tjänsten.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt överenskommelse med Karin Holm ska leveransen ske nästa vecka.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Björn Petersson och Cecilia Norström deltog i workshopen om hållbarhet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Projektledare: Gunnar Strand. Ansvarig tekniker: Sofia Lund.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 13,
+            "text_span": "Projektledare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 30,
+            "end": 47,
+            "text_span": "Ansvarig tekniker",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Chattlogg: Hej, jag heter Maja Hellström och undrar om ni kan hjälpa mig.",
+        "false_positives": [
+          {
+            "category": "article9.etniskt_ursprung",
+            "start": 26,
+            "end": 40,
+            "text_span": "Maja Hellström",
+            "confidence": 0.85,
+            "source": "article9.etniskt_ursprung",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "HR-notat: Anställd Per-Olof Lindberg påbörjar sin tjänst den första i månaden.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 10,
+            "end": 18,
+            "text_span": "Anställd",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 0,
+            "end": 8,
+            "text_span": "HR-notat",
+            "confidence": 0.85,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Undertecknad Therese Magnusson intygar att uppgifterna är korrekta.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt protokollet framförde Ingrid Karlsson synpunkter, vilket Fredrik Ek noterade.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 75,
+            "end": 83,
+            "text_span": "noterade",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Mötet hölls i Stockholm den tredje mars.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 14,
+            "end": 23,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Paketet levereras till Sveavägen 44 på fredag.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kundbesöket är inbokat i Göteborg nästa vecka.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 25,
+            "end": 33,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Tåget avgår från Malmö C kl. 08:15.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Lagret finns i Örebro och hanterar norra regionen.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 35,
+            "end": 49,
+            "text_span": "norra regionen",
+            "confidence": 0.95,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 15,
+            "end": 21,
+            "text_span": "Örebro",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Avtalet skrevs under av Volvo AB.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Skatteverket har begärt in kompletterande uppgifter.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi samarbetar med Acme Corp sedan 2018.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Fakturan gäller tjänster utförda åt Nordea Bank.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontraktet löper ut och Region Skåne har inte förlängt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Kontakta Anna Svensson på anna.svensson@foretag.se angående ärendet.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Erik Johansson, 820415-3426, är bosatt i Göteborg.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Volvo AB har registrerat IBAN SE35 5000 0000 0549 1000 0003.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ring Karin Holm på 070-123 45 67 för mer info om projektet i Malmö.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 61,
+            "end": 66,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Skatteverket kontaktade Lars Berg (lars.berg@privat.se) gällande deklarationen.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 35,
+            "end": 54,
+            "text_span": "lars.berg@privat.se",
+            "confidence": 0.0,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej,\n\nJag heter Sofia Ekström och mitt personnummer är 930715-1002. Jag har ett ärende gällande min senaste faktura som inte stämmer. Ni kan nå mig på sofia.ekstrom@mail.se eller ringa 073-555 12 34.\n\nMed vänliga hälsningar,\nSofia Ekström",
+        "false_positives": [
+          {
+            "category": "article4.namn",
+            "start": 225,
+            "end": 238,
+            "text_span": "Sofia Ekström",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "HR-notat 2026-03-15: Nyanställd Marcus Lindgren, personnummer 880312-1006, börjar som systemutvecklare på Ericsson AB den 1 april. Han är bosatt i Linköping och ska arbeta från kontoret på Teknikvägen 8.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 86,
+            "end": 102,
+            "text_span": "systemutvecklare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 86,
+            "end": 203,
+            "text_span": "systemutvecklare på Ericsson AB den 1 april. Han är bosatt i Linköping och ska arbeta från kontoret på Teknikvägen 8.",
+            "confidence": 0.92,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av yrkesroll (systemutvecklare), organisation (Ericsson AB) och specifik plats (Teknikvägen 8) ger tillräcklig identifierbarhet för en person med viss kunskap om den specifika företagsplatsen.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Ekonomirapport Q1 2026\n\nHandelsbanken har bekräftat att överföringen till leverantören Anna-Karin Bergström genomfördes den 12 mars. Beloppet krediterades IBAN SE90 8000 5555 4444 3333 2222. Vid frågor, kontakta ekonomiavdelningen på ekonomi@foretaget.se.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 14,
+            "text_span": "Ekonomirapport",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 234,
+            "end": 254,
+            "text_span": "ekonomi@foretaget.se",
+            "confidence": 0.0,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärende #4521 – Omtvistad transaktion\n\nKund: Henrik Sjöberg\nKortnummer: 4532 8901 2345 6785\nHenrik rapporterar en okänd debitering på 2 450 kr den 28 februari. Han nås enklast via telefon 070-888 99 11 eller på henrik.sjoberg@example.com. Ärendet eskaleras till bedrägerienheten.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 261,
+            "end": 277,
+            "text_span": "bedrägerienheten",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 38,
+            "end": 58,
+            "text_span": "Kund: Henrik Sjöberg",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 238,
+            "end": 278,
+            "text_span": "Ärendet eskaleras till bedrägerienheten.",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik kund (Henrik Sjöberg) och den specifika organisationen (bedrägerienheten) ger tillräcklig identifierbarhet för en person med viss kunskap om företagets interna struktur.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Protokoll från styrelsemöte 2026-04-10\n\nNärvarande: Eva Nilsson (ordförande), Karl Hedlund (ledamot) och Fatima Al-Hassan (sekreterare).\n\nMötet hölls i Göteborgs lokaler hos Sigma IT. Eva Nilsson öppnade mötet och noterade att samtliga ledamöter var närvarande. Nästa möte planeras till den 8 maj.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 138,
+            "end": 182,
+            "text_span": "Mötet hölls i Göteborgs lokaler hos Sigma IT",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av den specifika platsen (Göteborgs lokaler hos Sigma IT) ger tillräcklig identifierbarhet för en person med kännedom om denna plats och organisation.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 152,
+            "end": 161,
+            "text_span": "Göteborgs",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.namn",
+            "start": 184,
+            "end": 195,
+            "text_span": "Eva Nilsson",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article4.namn",
+            "start": 105,
+            "end": 121,
+            "text_span": "Fatima Al-Hassan"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lena,\n\nJag skriver angående utbetalningen till Jonas Wikström. Hans personnummer är 760924-1000 och beloppet ska sättas in på kontot med IBAN SE84 1200 3456 7890 1234 5678.\n\nSwedbank har bekräftat att kontot är aktivt. Kan du verifiera uppgifterna och genomföra överföringen?\n\nTack på förhand,\nLena",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 178,
+            "end": 186,
+            "text_span": "Swedbank"
+          }
+        ]
+      },
+      {
+        "text": "Incidentrapport – IT-säkerhet 2026-04-22\n\nRapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67.\nIncidenten upptäcktes av Teknik AB:s driftteam i Uppsala. En obehörig inloggning registrerades från en extern IP-adress kl. 03:14. Åtkomsten spärrades omedelbart och ärendet har rapporterats till CERT-SE.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 42,
+            "end": 117,
+            "text_span": "Rapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67",
+            "confidence": 0.9,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 42,
+            "end": 153,
+            "text_span": "Rapportör: Björn Axelsson, bjorn.axelsson@teknikab.se, telefon 08-123 45 67.\nIncidenten upptäcktes av Teknik AB",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik person (Björn Axelsson) och den specifika organisationen (Teknik AB) ger tillräcklig identifierbarhet för en person med kunskap om Teknik AB.",
+              "validation_path": "reconstructed"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Betalningsbekräftelse\n\nKund: Petra Forsberg, anställd vid SEB Kort AB.\nBetalning mottagen via kort 4012 8888 8888 8811 den 15 april 2026. Beloppet 12 500 kr har bokförts. Kvitto skickas till petra.forsberg@seb.se.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Ärendelogg – Socialförvaltningen Malmö kommun\n\nÄrende öppnat: 2026-02-20\nKlient: Amira Hassan, personnummer 950503-1006, boende Rosengård.\nKontaktuppgifter: 076-200 33 44.\n\nAnteckning: Klienten har begärt stödinsats enligt SoL kap. 4 §1. Handläggare tilldelad. Uppföljningsmöte planeras inom två veckor.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 33,
+            "end": 38,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 39,
+            "end": 45,
+            "text_span": "kommun",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 33,
+            "end": 45,
+            "text_span": "Malmö kommun"
+          }
+        ]
+      },
+      {
+        "text": "Faktura #2026-0891\n\nFrån: Nordström Consulting AB, Vasagatan 12, Stockholm\nTill: Oskar Blom, oskar.blom@kund.se\n\nBelopp: 45 000 kr exkl. moms.\nBetalning sker till IBAN SE69 3000 1234 5678 9012 3456 senast 2026-05-15.\n\nVid frågor, kontakta oss på faktura@nordstromconsulting.se.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 51,
+            "end": 60,
+            "text_span": "Vasagatan",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article4.iban",
+            "start": 168,
+            "end": 197,
+            "text_span": "SE69 3000 1234 5678 9012 3456"
+          }
+        ]
+      },
+      {
+        "text": "Hej Malin! Hoppas du mår bra efter semestern. Jag har en fråga angående din arbetsskada från förra sommaren. Har du fortfarande ont i knät? Det är viktigt att vi ser till att du får rätt stöd och rehabilitering för att kunna komma tillbaka till jobbet fullt ut.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 76,
+            "end": 107,
+            "text_span": "arbetsskada från förra sommaren",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.halsodata",
+            "start": 76,
+            "end": 87,
+            "text_span": "arbetsskada"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lisa, jag hoppas du mår bättre! Jag tänkte bara höra om hur det gick med din reumatologbesök igår. Har läkaren sagt något mer om dina besvär? Hoppas att du får bra hjälp och snabb lindring.",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 133,
+            "end": 144,
+            "text_span": "dina besvär",
+            "confidence": 0.85,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Sofia, \n\nJag skrev till dig för att få en uppdatering på hur det går med din handledare. Jag vet att du har varit sjukskriven sedan förra veckan med magsjukan och jag vill bara kolla om allt är lugnt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, fick ett mail från Lars igår - han är inte på jobbet idag utan har ringt in sjuk. Han nämnde att han hade ont i magen sedan igår kväll och misstänker det kan vara matförgiftning. Hörde du någonting mer om det?",
+        "false_positives": [
+          {
+            "category": "article9.halsodata",
+            "start": 73,
+            "end": 90,
+            "text_span": "har ringt in sjuk",
+            "confidence": 0.95,
+            "source": "article9.halsodata",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Sofia, \n\nJag vet att du är ledig idag men jag tänkte höra om hur det går med dig efter operationen. Jag hoppas allt läker bra och att du inte har ont.\n\nHälsningar,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan, snabb fråga om det politiska läget inför valet. Kanske vi kan diskutera vilka partier som verkar bäst för företaget och våra anställda? Jag själv lutar åt en mer liberala linje när det gäller ekonomisk politik. Vad tycker du?",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 117,
+            "end": 126,
+            "text_span": "företaget",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 147,
+            "end": 156,
+            "text_span": "Jag själv",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars! Kul att du deltar i den här diskussionen om framtidens arbetsmarknad. Jag såg att du är aktivt engagerad i Unga Socialdemokrater, det är imponerande! Vi har en spännande idé för ett nytt projekt som vi tror kan vara bra för unga arbetare. Vill du diskutera det mer på Zoom imorgon?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej! Har du sett att det är full fart på anmälan till den kristna ungdomsgruppen som håller till i kyrkan? Vi behöver nog fler ledare, vad säger du?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej! \n\nJag har precis fått en förfrågan från en kund, som heter Lars. Han vill beställa ett presentkort till sin dotter som firar sina 18-år. Han nämnde att hon är väldigt aktiv i den baptistförsamlingen på Södermalm och gärna skulle använda presentkortet till att köpa böcker om religion.",
+        "false_positives": [
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 265,
+            "end": 288,
+            "text_span": "köpa böcker om religion",
+            "confidence": 0.85,
+            "source": "article9.religios_overtygelse",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 207,
+            "end": 216,
+            "text_span": "Södermalm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan, \n\nJag hoppas allt är bra! Vi har ett fackligt möte imorgon kl 10:00 i konferensrummet för att diskutera den nya arbetstidsmodellen. Det är viktigt att alla fackliga representanter från vår avdelning deltar, särskilt du som är skyddsombud för Unionen. \n\nMed vänlig hälsning,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 238,
+            "end": 261,
+            "text_span": "skyddsombud för Unionen",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (skyddsombud) och den namngivna organisationen (Unionen) gör individen identifierbar, eftersom det är ett unikt roll-organisation-par i arbetsmiljön.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, \n\nJag vill kolla med dig om den kommande fackföreningsmötet. Jag har hört att du är skyddsombud för Byggnads? Det skulle vara kul att höra mer om vad som diskuteras. ",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 88,
+            "end": 118,
+            "text_span": "du är skyddsombud för Byggnads",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (skyddsombud) och en specifik organisation (Byggnads) ger tillräcklig identifierbarhet, eftersom det är ett unikt kombinationsätt som riktar sig mot en viss person.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars!\n\nVi har ett möte imorgon kl 10:00 för att diskutera den nya avtalsrörelsen. Det är viktigt att alla fackföreningsmedlemmar deltar eftersom det rör löneförhandlingar och arbetstidsregler.\n\nHälsningar,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, hoppas du mår bra! \n\nJag tänkte fråga om det går att få in din biometriska data i vårt system. Vi använder fingeravtryck för autentisering och det skulle underlätta arbetet med åtkomst till vissa filer. Skicka gärna ett mail tillbaka när du har tid att diskutera detta.",
+        "false_positives": [
+          {
+            "category": "article9.biometrisk_data",
+            "start": 69,
+            "end": 89,
+            "text_span": "din biometriska data",
+            "confidence": 0.95,
+            "source": "article9.biometrisk_data",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, det var kul att träffas på lunch igår! Vi behöver bara göra ett litet justering i systemet för att du ska kunna logga in med ditt ansikte. Har du möjlighet att komma hit och testa det imorgon morse?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Jonas!\n\nJag har testat det nya säkerhetssystemet med ansiktsigenkänning. Det fungerade bra! Mina kollegor tyckte också att det var smidigt att logga in med ansiktet, de sa att det kändes mer futuristiskt än att använda fingeravtryck. \n\nVad tycker du om att vi implementerar detta på vårt kontor?\n\nMvh,\nSofia",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 101,
+            "end": 109,
+            "text_span": "kollegor",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars, \n\nKan du hjälpa mig med det här? Vi har ett problem med vårt nya biometriska låssystem. Det verkar som att Lisa's ansiktssigenkänning inte fungerar korrekt. Hon har provat flera gånger men systemet accepterar inte hennes mätningar. Kan du kolla in det så fort som möjligt?",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,  \n\nVi har ett problem med det nya biometriska låssystemet. Det verkar felaktigt identifiera vissa användare, till exempel registrerar det inte alltid Annas ansikte korrekt när hon försöker logga in. Kan du ta en titt på systemet och se om du hittar felet? \n\nMvh,\nJohan",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nJag vill berätta att jag har fått tillbaka resultatet från mina genetiska analyser. Det visade sig att jag har en högre risk för utveckla hjärtkärlsjukdomar än genomsnittet, men inget som är akut eller behöver någon omedelbar åtgärd. Vi kan diskutera det mer när du har tid. \n\nMvh,\nLisa",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 71,
+            "end": 94,
+            "text_span": "mina genetiska analyser"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lena! Har du sett Anna på sjukhuset idag? Hon verkar lite låg i energi och berättade att hon nyligen gjorde en genetisk testning som visade att hon har en förhöjd risk för diabetes. Det är ju tråkigt, men hoppas det inte blir något allvarligt.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Anna jobbade som genetisk rådgivare på ett privat företag. En klient, Lars, hade genomgått en DNA-analys och fick besked att han har en högre risk att utveckla Parkinsons sjukdom än genomsnittet. Anna förklarade för Lars att detta inte betyder att han automatiskt kommer att få sjukdomen, utan att det är ett resultat av hans genetiska profil. Hon rekommenderade honom att prata med sin läkare om riskerna och möjliga förebyggande åtgärder.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 39,
+            "end": 57,
+            "text_span": "ett privat företag",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 17,
+            "end": 35,
+            "text_span": "genetisk rådgivare",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 0,
+            "end": 57,
+            "text_span": "Anna jobbade som genetisk rådgivare på ett privat företag",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av yrkesroll (genetisk rådgivare) och organisation (ett privat företag) ger tillräcklig identifierbarhet, speciellt i en kontext där det finns många genetiska rådgivare på privata företag.",
+              "validation_path": "exact"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, hoppas du mår bra! Jag skrev för att höra om det genetiska testet som du beställde. Det visade sig att du har en predisponering för diabetes typ 2, men det betyder inte nödvändigtvis att du kommer att utveckla sjukdomen. Vi kan diskutera riskerna och vilka åtgärder du kan vidta för att minska din risk. Ring gärna om du vill prata mer om det.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, hoppas du mår bra! Jag har fått ett mail från en kund som vill att vi ska analysera deras släktforskningsresultat. De nämner att de har hittat en genetisk koppling till en känd släkting med Down syndrom och är oroliga för att det kan vara något fel med deras egna barn. Vi behöver diskutera hur vi ska handskas med detta, eftersom det rör känslig information om deras familj.",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "article9.genetisk_data",
+            "start": 200,
+            "end": 212,
+            "text_span": "Down syndrom"
+          }
+        ]
+      },
+      {
+        "text": "Hej Johan! Jag skrev bara för att höra hur det går med projektet. Har du hunnit diskutera designen med din pojkvän, som jag vet är superkunnig inom detta område?",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 131,
+            "end": 160,
+            "text_span": "superkunnig inom detta område",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars! Jag såg att du var med på Pride-paraden i Stockholm igår. Var det kul? Jag tänkte eventuellt gå nästa år. Det är ju så inspirerande att se alla människor som vågar visa sin kärlek och sitt stöd för varandra.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 52,
+            "end": 61,
+            "text_span": "Stockholm",
+            "confidence": 0.99,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 52,
+            "end": 61,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan, hoppas du har en bra dag! Har du koll på när vi ska ha det mötet med kunden från XYZ AB? Jag skickade ett mail om det igår men fick inget svar. Hör av dig när du får chansen!\n\nMvh,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 81,
+            "end": 99,
+            "text_span": "kunden från XYZ AB",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 93,
+            "end": 99,
+            "text_span": "XYZ AB",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan, \n\nKan du kolla om det är möjligt att få de nya brochuresna i tryck imorgon? Behövs dem för mötet med kunderna på tisdag. \n\nMår bra annars! \n\nMvh,\nErik",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, Har du koll på den nya designen för hemsidan? Det verkar som att det är några små buggar kvar. Kan vi snabbt hoppa på Teams imorgon för att gå igenom det?",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 128,
+            "end": 133,
+            "text_span": "Teams",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan! Kan du kolla igenom den här rapporten och ge mig feedback innan måndagens möte? \n\nMvh,\nJohanna\n\n[Bifogat: Rapport.docx]",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan, \n\nKan du kolla igenom den här presentationen och ge feedback innan mötet imorgon? \n\n//Linnea\n\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lisa, \n\nKan du kolla om den nya produktkatalogen är klar? Behöver den imorgon för att skicka till trycket. \n\nMvh,\nAnna\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla om den nya produktkatalogen är klar? Behöver den till lunchmötet med kunderna imorgon. \n\nMvh,\nJohan \n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nKan du kolla om det går att få igenom den nya fakturan från \"Teknisk Service AB\" till redovisningen? Det står på fakturan att de ska betalas senast den 15:e.  Hör gärna av dig när du gjort det!\n\nMvh,\nAnna\n",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 73,
+            "end": 91,
+            "text_span": "Teknisk Service AB",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,  \n\nHar du hunnit se den nya designen för broschyren? Kan du ge mig feedback innan måndagen så vi hinner ändra den om det behövs. \n\nMvh, \nLars\n",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla om det finns budget kvar för att köpa nya möbler till kontoret? Vi behöver definitivt uppdatera den här sofforiten! 😅  Hör gärna av dig när du har en stund. \n\nMvh,\nErik",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna, \n\nKan du kolla igenom den nya produktkatalogen och ge feedback senast fredag? Har skickat den till din e-post. \n\nMvh,\nLars",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anders,\n\nHoppas du har haft en bra vecka! Kan du kolla in den nya designen för hemsidan? Jag skickade den till din mail igår. Låt mig veta vad du tycker!\n\nMvh,\nSara",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,\n\nTack för att du tog upp det på mötet igår. Jag håller helt med dig om att vi borde rösta nej till det nya förslaget om utökad kameraövervakning på arbetsplatsen. Det strider mot grundläggande integritetsprinciper.\n\nMvh,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nJag såg att du kandiderar för Vänsterpartiet i höstens val. Det är modigt! Jag vet att det inte alltid är enkelt att vara öppen med politiska engagemang på arbetsplatsen.\n\nMvh,\nKarin",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,\n\nJag hittade din insändare i Aftonbladet där du skriver att Sverigedemokraterna bör uteslutas från samtliga riksdagsutskott. Ska vi ta upp det på nästa personalmöte eller håller du det privat?\n\nMvh,\nStefan",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lena,\n\nEfter senaste styrelsemötet är det tydligt att Erik är en övertygad förespråkare för privatisering av sjukvården. Han argumenterade bestämt för att landstingen borde lägga ut mer på privata aktörer.\n\nMvh,\nMaria",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Stefan,\n\nJag vill bara flagga att Fatima inte kan delta i fredagsmötet. Hon har bett om att få ledigt för fredagsbönen och det har vi självklart godkänt.\n\nMvh,\nAnna",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lisa,\n\nJag har fått in en förfrågan från Lars om att byta sina semesterdagar. Han vill ha ledigt under påskveckan eftersom han och hans familj brukar fira påsk i kyrkan med sina barn.\n\nMvh,\nJohan",
+        "false_positives": [],
+        "false_negatives": [
+          {
+            "category": "article9.religios_overtygelse",
+            "start": 154,
+            "end": 172,
+            "text_span": "fira påsk i kyrkan"
+          }
+        ]
+      },
+      {
+        "text": "Hej!\n\nVi behöver uppdatera personalregistret. Ahmed har meddelat att han är aktiv i den lokala moskéförsamlingen och önskar att det noteras för att undvika mötesbokningar under ramadan.\n\nMvh,\nPersonalavdelningen",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 192,
+            "end": 211,
+            "text_span": "Personalavdelningen",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Anna,\n\nKarin har berättat att hon numera är Jehovas vittne och därför inte längre kan delta i firandet av jul och midsommar på kontoret. Vi behöver tänka på hur vi hanterar det framöver.\n\nMvh,\nPer",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 131,
+            "end": 139,
+            "text_span": "kontoret",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nLycka till på din vigsel imorgon! Hoppas dagen med Marcus blir allt ni har drömt om.\n\nVarma hälsningar,\nLena",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Maria,\n\nJag ville höra om du kan ta över Annas arbetspass på torsdag. Hon behöver ledigt för att hämta sin flickvän på flygplatsen.\n\nMvh,\nStefan",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 123,
+            "end": 134,
+            "text_span": "flygplatsen",
+            "confidence": 0.95,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "context.yrke",
+            "start": 111,
+            "end": 119,
+            "text_span": "flickvän",
+            "confidence": 0.85,
+            "source": "context.yrke",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 107,
+            "end": 119,
+            "text_span": "sin flickvän"
+          }
+        ]
+      },
+      {
+        "text": "Hej Lars,\n\nJag har sett att Erik är ordförande i företagets HBTQ-nätverk och öppet homosexuell. Är det något vi bör ta hänsyn till vid kundmötena i Mellanöstern nästa kvartal?\n\nMvh,\nAnna",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 28,
+            "end": 72,
+            "text_span": "Erik är ordförande i företagets HBTQ-nätverk",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ordförande) och en specifik organisation (företagets HBTQ-nätverk) ger tillräcklig identifierbarhet, eftersom det är ett unikt nätverk inom ett företag. Detta kombinerat med Erik som personnamn skulle ge starkt identifierbarhet.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 148,
+            "end": 160,
+            "text_span": "Mellanöstern",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej!\n\nEtt förtydligande inför konferensen: Karin och hennes fru Lisa bor på samma rum under övernattningen. Bokningsavdelningen ska notera detta.\n\nMvh,\nAdministrationen",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 108,
+            "end": 127,
+            "text_span": "Bokningsavdelningen",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 152,
+            "end": 168,
+            "text_span": "Administrationen",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.sexuell_laggning",
+            "start": 53,
+            "end": 68,
+            "text_span": "hennes fru Lisa"
+          }
+        ]
+      },
+      {
+        "text": "Hej Stefan,\n\nJag fick precis bekräftelse från IF Metall att du är registrerad som medlem hos dem. Det innebär att du omfattas av det kollektivavtal vi tecknat.\n\nMvh,\nHR",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 46,
+            "end": 55,
+            "text_span": "IF Metall",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          },
+          {
+            "category": "context.organisation",
+            "start": 166,
+            "end": 168,
+            "text_span": "HR",
+            "confidence": 0.8,
+            "source": "entity.spacy_ORG",
+            "metadata": {
+              "ner_label": "ORG"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "article9.fackmedlemskap",
+            "start": 66,
+            "end": 96,
+            "text_span": "registrerad som medlem hos dem"
+          }
+        ]
+      },
+      {
+        "text": "Hej Anna,\n\nJag vill informera om att Maja har gått med i Lärarförbundet sedan förra månaden. Hon har bett om att få delta i deras utbildningsdagar den 12 mars.\n\nMvh,\nPer",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Johan,\n\nFör att hantera löneförhandlingen korrekt behöver vi veta om Lars är medlem i Unionen eller Akademikerförbundet SSR. Han har tidigare nämnt att han betalar fackkontingent till Unionen.\n\nMvh,\nEkonomi",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 90,
+            "end": 97,
+            "text_span": "Unionen",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          },
+          {
+            "category": "context.organisation",
+            "start": 104,
+            "end": 127,
+            "text_span": "Akademikerförbundet SSR",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Hej Lars,\n\nVi har registrerat Saras röstavtryck i telefonisystemet så att hon kan autentisera sig vid inloggning. Systemet kräver att hon läser upp en kort fras vid varje inloggning.\n\nMvh,\nIT-avdelningen",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Förslagsgruppen bestod av VD för Hvitfeldtska gymnasiets musiklinje och professor emeritus vid Göteborgs universitet.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 95,
+            "end": 116,
+            "text_span": "Göteborgs universitet",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": {
+              "deduplicated_sources": [
+                "entity.spacy_ORG"
+              ]
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Rektor på Hvitfeldtska gymnasiets musiklinje har bett mig att kontakta läkare i Göteborg om akut tandvård för hennes dotter.",
+        "false_positives": [
+          {
+            "category": "context.plats",
+            "start": 80,
+            "end": 88,
+            "text_span": "Göteborg",
+            "confidence": 0.99,
+            "source": "context.plats",
+            "metadata": null
+          },
+          {
+            "category": "article9.halsodata",
+            "start": 92,
+            "end": 123,
+            "text_span": "akut tandvård för hennes dotter",
+            "confidence": 0.95,
+            "source": "article9.halsodata",
+            "metadata": null
+          },
+          {
+            "category": "article4.adress",
+            "start": 80,
+            "end": 88,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Professor Lars Eriksson, rektor på Hvitfeldtska gymnasiets musiklinje, meddelade personalen att de förväntade sig ett ökat antal elever.",
+        "false_positives": [
+          {
+            "category": "context.yrke",
+            "start": 0,
+            "end": 9,
+            "text_span": "Professor",
+            "confidence": 0.95,
+            "source": "context.yrke",
+            "metadata": null
+          },
+          {
+            "category": "article4.namn",
+            "start": 10,
+            "end": 23,
+            "text_span": "Lars Eriksson",
+            "confidence": 0.8,
+            "source": "entity.spacy_PRS",
+            "metadata": {
+              "ner_label": "PRS"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "En legitimerad tandläkare vid Västra Götalandsregionens tandvårdscenter i Borås har rapporterat ett misstänkt fall av bakterielinfektion.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 30,
+            "end": 55,
+            "text_span": "Västra Götalandsregionens",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 74,
+            "end": 79,
+            "text_span": "Borås",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Sjuksköterskan på intensivvården vid Sahlgrenska Universitetssjukhuset i Göteborg tog emot patienten från Hallands sjukhus.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 73,
+            "end": 81,
+            "text_span": "Göteborg",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 106,
+            "end": 114,
+            "text_span": "Hallands",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Förläggaren för den nya elbilen, Volvo Cars, har etablerat ett produktionscenter i Trollhättan. De anställda där arbetar som montörer och mekaniker med hög specialisering inom elbilsteknik.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 83,
+            "end": 94,
+            "text_span": "Trollhättan",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 125,
+            "end": 133,
+            "text_span": "montörer"
+          }
+        ]
+      },
+      {
+        "text": "Avdelningschefen på vårdcentralen i Karlskoga diskuterade med den nya sjuksköterskan om patientflödet.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 36,
+            "end": 45,
+            "text_span": "Karlskoga",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 70,
+            "end": 84,
+            "text_span": "sjuksköterskan"
+          },
+          {
+            "category": "context.organisation",
+            "start": 20,
+            "end": 45,
+            "text_span": "vårdcentralen i Karlskoga"
+          }
+        ]
+      },
+      {
+        "text": "Den nya enhetschefen som tillträdde i januari efter omorganisationen vid Sahlgrenska Universitetssjukhuset har redan introducerat ett nytt schemasystem för hela avdelningen.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Den första kvinnliga produktionschefen på Volvo Cars Skövde, som rekryterades från huvudkontoret förra hösten, kommer att tala på branschkonferensen i juni.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Det nya lagret på industrivägen öppnar i morgon och de första anställda börjar sin utbildning. Den ansvariga förlogistikstrategen, som flyttat hit från huvudkontoret i Stockholm, har gett tydliga instruktioner om hur man ska hantera den höga arbetsbelastningen.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 168,
+            "end": 177,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 112,
+            "end": 129,
+            "text_span": "logistikstrategen"
+          }
+        ]
+      },
+      {
+        "text": "Under mötesdagen diskuterade projektledaren och den ekonomiska experten från huvudkontoret om de nya budgetplanerna för deras gemensamma projekt i Uppsala.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 77,
+            "end": 90,
+            "text_span": "huvudkontoret",
+            "confidence": 0.97,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 29,
+            "end": 154,
+            "text_span": "projektledaren och den ekonomiska experten från huvudkontoret om de nya budgetplanerna för deras gemensamma projekt i Uppsala",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av specifik yrkesroll (projektledare och ekonomisk expert) vid en specifik organisation (huvudkontoret) samt plats (Uppsala) ger tillräcklig identifierbarhet för den som har viss kännedom om projektet.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 147,
+            "end": 154,
+            "text_span": "Uppsala",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Han jobbade som projektledare på den kommunala vårdcentralen i Karlskrona under 2022. Han var inte nöjd med sin lön och började leta efter nya möjligheter.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 16,
+            "end": 73,
+            "text_span": "projektledare på den kommunala vårdcentralen i Karlskrona",
+            "confidence": 0.93,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (projektledare) och en specifik plats (den kommunala vårdcentralen i Karlskrona) ger tillräcklig identifierbarhet för en person med viss lokal kunskap.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 63,
+            "end": 73,
+            "text_span": "Karlskrona",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.organisation",
+            "start": 37,
+            "end": 60,
+            "text_span": "kommunala vårdcentralen"
+          }
+        ]
+      },
+      {
+        "text": "På mötet diskuterade vi med den nya ekonomichefen hur projektet skulle drivas framåt. Han har tidigare arbetat som konsult inom IT-sektorn, men är nu ansvarig för vår avdelning här på fabriken i Borås.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 184,
+            "end": 200,
+            "text_span": "fabriken i Borås",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.kombination",
+            "start": 36,
+            "end": 200,
+            "text_span": "ekonomichefen hur projektet skulle drivas framåt. Han har tidigare arbetat som konsult inom IT-sektorn, men är nu ansvarig för vår avdelning här på fabriken i Borås",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ekonomichef) och en specifik plats (fabriken i Borås) ger tillräcklig identifierbarhet för den som har viss kännedom om fabriken.",
+              "validation_path": "reconstructed"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Det var en anställd på receptionen som berättade att de nya systemen för bokning av mötesrum skulle bli tillgängliga i höst. Hon nämnde också att personalen på IT-avdelningen jobbade hårt med det, men att det fortfarande var lite oklart när exakt de skulle vara färdiga.",
+        "false_positives": [
+          {
+            "category": "context.organisation",
+            "start": 160,
+            "end": 174,
+            "text_span": "IT-avdelningen",
+            "confidence": 0.98,
+            "source": "context.organisation",
+            "metadata": null
+          },
+          {
+            "category": "context.organisation",
+            "start": 23,
+            "end": 34,
+            "text_span": "receptionen",
+            "confidence": 0.95,
+            "source": "context.organisation",
+            "metadata": null
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 11,
+            "end": 19,
+            "text_span": "anställd"
+          }
+        ]
+      },
+      {
+        "text": "Den automatiserade processen aktiverades klockan 14.37. En loggsändning registrerades med kodnamn 'Fjärilsdans'. Det följande skedet, 'Stjärnfall', väntas inledas inom de närmaste fem minuterna.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Systemet registrerar automatiskt alla förändringar i databasen. Varje uppdatering sparas med en timestamp för fullständig historik.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Protokollen för uppdatering av databasen kommer att ske vid två tillfällen per dag. Första gången sker klockan 07:00 och den andra klockan 15:00. Under perioden mellan dessa uppdateringar kan det uppstå små variationer i informationen.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "En ny regel för hantering av digitala filer implementeras den 15 november. Det innebär att alla dokument ska sparas i en centraliserad plats med automatiskt numreringssystem.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Automatiserad processen genomfördes enligt schema. Dataanalysen visade en ökning i volym under perioden, vilket påverkade systemhastigheten. Vidare utvärderades algoritmen för att minska energiförbrukning.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Enligt protokoll från den senaste iterationen ska den optimerade modellen gå igenom en komplex serie testfall. Syftet är att säkerställa att algoritmen hanterar olika scenarier korrekt och utan fel.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Lagledningen på konferensen diskuterade vikten av att anställa fler medarbetare med erfarenhet inom dataanalys och digital marknadsföring för att möta framtidens utmaningar.",
+        "false_positives": [],
+        "false_negatives": []
+      },
+      {
+        "text": "Att jobba som försäljningskonsult i Malmö kan vara utmanande, men också väldigt givande. Det är viktigt att ha god kundservice och ett starkt nätverk för att lyckas.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 36,
+            "end": 41,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 14,
+            "end": 33,
+            "text_span": "försäljningskonsult"
+          }
+        ]
+      },
+      {
+        "text": "På mötet diskuterade vi behovet av fler lärare inom den digitala utbildningen i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 80,
+            "end": 89,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Förra veckan deltog många lärare från Stockholm i konferensen om digitalisering inom skolan.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 38,
+            "end": 47,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "På mötet diskuterade vi hur många anställda som arbetade på kontoret i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 71,
+            "end": 80,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": [
+          {
+            "category": "context.yrke",
+            "start": 34,
+            "end": 43,
+            "text_span": "anställda"
+          }
+        ]
+      },
+      {
+        "text": "Det är alltid roligt att träffa nya kollegor på konferenser. I år var många från banksektorn i Stockholm.",
+        "false_positives": [
+          {
+            "category": "article4.adress",
+            "start": 95,
+            "end": 104,
+            "text_span": "Stockholm",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      },
+      {
+        "text": "Vi har fått många ansökningar om tjänster som ekonomichef i Malmö, men det var svårt att hitta rätt profil.",
+        "false_positives": [
+          {
+            "category": "context.kombination",
+            "start": 46,
+            "end": 65,
+            "text_span": "ekonomichef i Malmö",
+            "confidence": 0.85,
+            "source": "context.kombination",
+            "metadata": {
+              "reasoning": "Kombinationen av en specifik yrkesroll (ekonomichef) och en specifik plats (Malmö) ger tillräcklig identifierbarhet för att konstatera att det handlar om en viss person i Malmö.",
+              "validation_path": "exact"
+            }
+          },
+          {
+            "category": "article4.adress",
+            "start": 60,
+            "end": 65,
+            "text_span": "Malmö",
+            "confidence": 0.8,
+            "source": "entity.spacy_LOC",
+            "metadata": {
+              "ner_label": "LOC"
+            }
+          }
+        ],
+        "false_negatives": []
+      }
+    ],
+    "per_mechanism": {
+      "high_via_article9": 39,
+      "medium_via_bypass": 16,
+      "medium_via_mechanism3": 0,
+      "low_count": 63,
+      "none_count": 41
+    }
+  }
+}

--- a/docs/iteration_3_implementation.md
+++ b/docs/iteration_3_implementation.md
@@ -124,7 +124,7 @@ Status-legenda: ✅ Klar | 🔄 Pågår | ⏸️ Blockerad | ⬜ Ej startad
 | [#101](https://github.com/Abdriano95/aegis/issues/101) (I-1) | Promptskärpning för CombinationLayer context.yrke och context.organisation | A1 | Abdulla | ✅ Klar 2026-05-12 | Inga | Stärker DP1 Rationale; 4.5.2 ska uppdateras. |
 | [#102](https://github.com/Abdriano95/aegis/issues/102) (I-2) | Matcher-aliasing för article4.adress och context.plats | A2 | Johanna | ✅ Klar (2026-05-12) | Inga | 5.3 (arkitekturbeskrivning) uppdateras med aliasing-mekanism. |
 | [#103](https://github.com/Abdriano95/aegis/issues/103) (I-3) | Aggregator-deduplicering för same-category overlap över lager | A2 | Johanna | ✅ Klar (2026-05-12) | Inga (I-5 berör samma kod) | 5.3 uppdateras med dedupliceringsregel. |
-| [#104](https://github.com/Abdriano95/aegis/issues/104) (I-4) | Promptförbättringar för svaga artikel 9-kategorier | A1 | Abdulla | ⬜ Ej startad | Inga | Empiriskt material för DP1; 4.5.2 och 6.5/6.7 uppdateras. |
+| [#104](https://github.com/Abdriano95/aegis/issues/104) (I-4) | Promptförbättringar för svaga artikel 9-kategorier | A1 | Abdulla | ✅ Klar 2026-05-12 (rollback till v5, negativ empiri formaliserad - Beslut 48) | Inga | Empiriskt material för DP1; 4.5.2 och 6.5/6.7 uppdateras. |
 | [#105](https://github.com/Abdriano95/aegis/issues/105) (I-5) | Tvådimensionsoperationalisering enligt Variant 2 | A3 | Gemensamt | ⬜ Ej startad | I-3 | Villkorad DP6 (5.5); 5.3 klassdiagram och 4.4.3 uppdateras. |
 | [#106](https://github.com/Abdriano95/aegis/issues/106) (I-6) | Empirisk tröskelkalibrering | A4 | Johanna | ⬜ Ej startad | I-1, I-2, I-3, I-4, I-5 | Stärker DP1 Rationale; 4.5.2 och 5.2 uppdateras. |
 | [#107](https://github.com/Abdriano95/aegis/issues/107) (I-7) | Modellskalningsprob via större molnmodell | A1 | Johanna | ⬜ Ej startad | Inga (efter I-1–I-5) | Diskussionsmaterial för kapitel 6 (6.5/6.7). |
@@ -473,3 +473,77 @@ Båda körningarna genomfördes same-session på branch rebasad på origin/main 
 **Beslut fattade:** Revision av tidigare beslut 2026-05-12 (åtgärdsväg 1 → åtgärdsväg 2). Beslutsdokumentation i Loggboken (Google Docs, fliken "Loggbok - iteration 3"). Beslut 29:s scope utvidgas explicit till att omfatta enum-överträdelser av individuella signal-värden, inte enbart text_span-hallucinationer. Föregående sessions distinktion (schemafel vs. hallucination för enum) är överskriven av empirisk evidens.
 
 **Öppet/Nästa steg:** Förekomsten av 'person' som genererat signal-värde är empiriskt signal om prompt-lucka i CombinationLayer:s system prompt eller examples. Kandidat för prompt-revision i framtida iteration men inte i denna sessions scope. Markeras som öppen observation för iteration 3:s formaliseringsarbete. Pre-existing miljöfråga med `sv_core_news_lg` är åtgärdad och påverkar inte längre testkörningar.
+
+### Session 2026-05-12 - Claude Code (Opus 4.7) - I-4 Article9Layer v6-experiment, rollback till v5
+
+**Iteration:** 3 / v0.3.0-dev
+**Mål:** Promptförbättringar för Article9Layer:s tre underpresterande kategorier (halsodata, etniskt_ursprung, religios_overtygelse) per Beslut 33.
+
+**Utfall:** Negativ empiri. v6 inducerade strukturell regression i Article9Layer som helhet. Rollback till v5 genomförd. Det empiriska materialet bevaras som underlag för DP1 och rapportkapitel 6.5/6.7.
+
+**Ändrade filer:**
+- `gdpr_classifier/prompts/article9/v6.yaml` - skapad, sedan markerad experimentell i metadata (`status: "experimental"`, ny `notes` med rollback-pekare)
+- `gdpr_classifier/layers/article9/article9_layer.py` rad 27 - default `prompt_version` ändrades till "v6" och återställdes till "latest" efter rollback-beslutet (netto ingen ändring)
+- `scripts/build_demo_snapshot.py` rad 60 - `_DEFAULT_ARTICLE9_VERSION` ändrades till "v6" och återställdes till "v5" (netto ingen ändring)
+- `tests/unit/test_snapshot_loader.py` rad 54 - "article9"-metadata ändrades till "v6" och återställdes till "v5" (netto ingen ändring)
+- `docs/prompts_bilaga.md` - Article9Layer-sektionen utökad med v6-post markerad "experimentell, ej aktiv prompt"
+- `docs/iteration_3_implementation.md` - statusrad för #104 uppdaterad och denna sessionspost tillagd
+- `demo/snapshots/iteration_3_baseline_v5_reproduction.json` - same-session v5-reproduktion (genererad artefakt, bevaras)
+- `demo/snapshots/iteration_3_baseline_post_I4.json` - v6-körning (genererad artefakt, bevaras)
+
+**Gjort:**
+- Skapat v6.yaml enligt Beslut 33: utökade negativa exempel för halsodata (vaga humör- och energi-formuleringar), explicit negativa exempel för etniskt_ursprung (nordeuropeiska personnamn), positiva exempel för implicit kristet firande (julotta, dop, konfirmation) i religios_overtygelse. Utökade reasoning_instructions enligt Wei et al. (2022) med kort steg-för-steg-resoning. source_citations: Liu et al. (2023), Brown et al. (2020), Wei et al. (2022), Karras et al. (2025). decision_ref: Beslut 44.
+- Bumpat tre pinningar till "v6": Article9Layer.__init__ default, build_demo_snapshot.py `_DEFAULT_ARTICLE9_VERSION`, test_snapshot_loader.py metadata
+- Kört pytest: 178/178 passerade
+- Genererat same-session v5-reproduktion-snapshot på commit `164a6fe`
+- Genererat v6-snapshot same-session på samma commit
+- Beräknat per-kategori-mätvärden från båda snapshots
+- Identifierat strukturell regression i Article9Layer som helhet (total FP 7 till 14) plus sidoeffekter i sexuell_laggning (recall -33.3 pp) och genetisk_data (recall -14.3 pp)
+- Returnerat resultat och rotorsaksanalys till arkitekt-agenten för granskning
+- Genomfört rollback efter arkitekt-godkännande: återställt tre pinningar, markerat v6.yaml som experimentell i metadata (`status` och `notes`-uppdatering), uppdaterat dokumentation (prompts_bilaga.md, denna fil)
+
+**Mätvärden (qwen2.5:7b-instruct, 159 texter, 2026-05-12, same-session på commit `164a6fe`):**
+
+| Kategori | v5-reproduktion TP/FP/FN | v6 TP/FP/FN | ΔFP | ΔRecall pp |
+|---|---|---|---|---|
+| article9.halsodata | 6/4/1 | 7/5/0 | +1 | +14.3 |
+| article9.etniskt_ursprung | 0/1/0 | 0/0/0 | -1 | 0 |
+| article9.religios_overtygelse | 5/1/1 | 6/5/0 | +4 | +16.7 |
+| article9.biometrisk_data | 6/1/0 | 6/2/0 | +1 | 0 |
+| article9.genetisk_data | 5/0/2 | 4/2/3 | +2 | -14.3 |
+| article9.sexuell_laggning | 4/0/2 | 2/0/4 | 0 | -33.3 |
+| article9.fackmedlemskap | 5/0/1 | 5/0/1 | 0 | 0 |
+| article9.politisk_asikt | 6/0/0 | 6/0/0 | 0 | 0 |
+| Article9Layer total | 37/7/0 | 36/14/0 | +7 | 0 |
+| Pipeline total | 214/93/19 | 213/99/20 | +6 | -0.4 |
+
+**Baseline-anomali mot Johannas post-I-3-baseline:** v5-reproduktion TP=214/FP=93/FN=19 vs Johannas committade TP=212/FP=97/FN=21. Inom 4 FP totalt. Ingen sekundär anomali att dokumentera.
+
+**Rotorsaksanalys:**
+
+Tre mekanismer förklarar regressionen.
+
+1. Övergeneralisering av implicit kristet firande. v6:s positiva exempel (julotta, dop, konfirmation) fick modellen att klassificera sekulärt firande (jul, midsommar) som religios_overtygelse trots explicit negativ regel i task_instruction. Konkret observation: v6 FP "firandet av jul och midsommar" i text utan kyrklig kontext, vilket v5 korrekt avstod från att klassificera.
+
+2. Kategorikonfusion mellan religios_overtygelse och sexuell_laggning. Tillägget av "kyrklig vigsel" i religios_overtygelse-listan tippade modellen att klassificera samkönad vigsel som religiös. Konkreta observationer: "Johan + Marcus vigsel", "hennes fru Lisa" och "Pride-paraden" klassades alla som religios_overtygelse i v6, vilket v5 korrekt klassat som sexuell_laggning. Detta är primärorsaken till -33.3 pp recall i sexuell_laggning.
+
+3. Kategorikonfusion mellan halsodata och genetisk_data. Den utökade CoT-resoningen i reasoning_instructions tippade gränsfall mot halsodata istället för genetisk_data. Konkreta observationer: "han har en högre risk att utveckla Parkinsons sjukdom än genomsnittet" och "genetiska testet som du beställde" klassades som halsodata i v6, trots att v5 korrekt klassat dem som genetisk_data per v5:s explicita exempel.
+
+**Acceptanskriterier:**
+- DoD-2a halsodata FP-reduktion: MISSLYCKAT (4 till 5 FP, +1)
+- DoD-2b etniskt_ursprung FP-reduktion: UPPFYLLT (1 till 0)
+- DoD-2c religios_overtygelse recall: UPPFYLLT (83.3 till 100 procent, +16.7 pp), men till priset av +4 FP i samma kategori och -33.3 pp recall i sexuell_laggning som sidoeffekt
+
+**Beslut:** Rollback till v5 som aktiv prompt. v6 bevaras som experimentell artefakt med metadata-markering (`status: "experimental"` och utökad `notes` med pekare till denna sessionspost). Formaliserat som Beslut 48 i Loggboken iteration 3.
+
+**Koppling till tidigare beslut:** v6:s utfall bekräftar empiriskt Beslut 33:s prediktion att modellen ignorerar negativa promptinstruktioner konsekvent när få-shot-mönstret kolliderar med textuell likhet. Beslut 48 formaliserar att fortsatt promptarbete inom samma metodik avslutas för dessa kategorier; framtida förbättringar kräver ny metodik snarare än fler iterationer av samma slag.
+
+**Formaliseringskonsekvens (per Beslut 33 och Beslut 48):** Det empiriska materialet bidrar till DP1 (Designprincip 1) som evidens för att prompt-engineering ensam är otillräcklig för kategoriska gränsdragningsproblem hos 7B-modeller. AEGIS-rapportens kapitel 4.5.2 (designcykel 3:s konstruktion) ska beskriva experimentet inklusive negativt utfall som del av iteration 3:s designarbete. Kapitel 6.5 eller 6.7 ska reflektera över modellens hantering av negativa instruktioner med v6:s utfall som empirisk illustration. Rapportarbetet utförs utanför agent-flödet av Abdulla och Johanna.
+
+**Bevarade artefakter:**
+- `gdpr_classifier/prompts/article9/v6.yaml` (markerad experimentell i metadata)
+- `demo/snapshots/iteration_3_baseline_v5_reproduction.json`
+- `demo/snapshots/iteration_3_baseline_post_I4.json`
+- `docs/prompts_bilaga.md` v6-post med pekare hit
+
+**Öppet/Nästa steg:** Beslut 48 skapas manuellt av användaren i Loggboken iteration 3 (Google Docs) parallellt med denna commit. Kommitthash i `docs/prompts_bilaga.md` v6-postens "Kommitthash"-fält är platshållare och uppdateras i en follow-up-docs-commit direkt efter huvud-commit. Eventuella framtida förbättringar av Article9Layer:s underpresterande kategorier kräver ny metodik (arkitektonisk förändring, modellbyte, hybrid-approach), inte fortsatt prompt-iteration inom samma ramverk.

--- a/docs/prompts_bilaga.md
+++ b/docs/prompts_bilaga.md
@@ -84,7 +84,7 @@ spårbarheten kräver det utöver kodhistoriken.
 
 - **Fil:** [`gdpr_classifier/prompts/article9/v6.yaml`](../gdpr_classifier/prompts/article9/v6.yaml)
 - **Datum:** 2026-05-12
-- **Kommitthash:** `<HASH_TBD>`
+- **Kommitthash:** d500b950b76fc64ac11eef8f52c94ae67ed5ccac
 - **Iteration:** 3 / v0.3.0-dev
 - **Issue:** [#104](https://github.com/Abdriano95/aegis/issues/104) (I-4)
 - **Designbeslut:** Beslut 48 (Loggbok iteration 3) - rollback. Tidigare designintention enligt Beslut 33 (Loggbok iteration 2) och Beslut 44 (Loggbok iteration 3, prompt-konstruktionsmetod).

--- a/docs/prompts_bilaga.md
+++ b/docs/prompts_bilaga.md
@@ -80,8 +80,35 @@ spårbarheten kräver det utöver kodhistoriken.
 
 ## Article9Layer
 
-Posterna fylls i när artikel 9-prompten revideras (issue
-[#104](https://github.com/Abdriano95/aegis/issues/104), I-4). Den aktuella
-v5-versionen av Article9Layer ligger under
-[`gdpr_classifier/prompts/article9/`](../gdpr_classifier/prompts/article9/) och
-dokumenteras i sin YAML-metadata.
+### v6 (experimentell, ej aktiv prompt)
+
+- **Fil:** [`gdpr_classifier/prompts/article9/v6.yaml`](../gdpr_classifier/prompts/article9/v6.yaml)
+- **Datum:** 2026-05-12
+- **Kommitthash:** `<HASH_TBD>`
+- **Iteration:** 3 / v0.3.0-dev
+- **Issue:** [#104](https://github.com/Abdriano95/aegis/issues/104) (I-4)
+- **Designbeslut:** Beslut 48 (Loggbok iteration 3) - rollback. Tidigare designintention enligt Beslut 33 (Loggbok iteration 2) och Beslut 44 (Loggbok iteration 3, prompt-konstruktionsmetod).
+- **Designintention (vad v6 skulle uppnå):** Per Beslut 33 utpekade iteration 2:s utvärdering tre Article9Layer-kategorier som underpresterande: `halsodata` (vaga formuleringar triggade FP), `etniskt_ursprung` (nordeuropeiska personnamn felklassades som etnisk markör), `religios_overtygelse` (implicit kristet firande missades i recall). v6 förstärkte negativa exempel för halsodata, lade till nordeuropeiska namn som negativa exempel för etniskt_ursprung, och introducerade positiva exempel för implicit kristet firande (julotta, dop, konfirmation) i religios_overtygelse. Reasoning_instructions utökades med kort steg-för-steg-resoning per Wei et al. (2022).
+- **Empiriskt utfall (qwen2.5:7b-instruct, 159 texter, 2026-05-12, same-session jämförelse mot v5-reproduktion på commit `164a6fe`):**
+
+  | Kategori | v5-reproduktion TP/FP/FN | v6 TP/FP/FN | ΔFP | ΔRecall pp |
+  |---|---|---|---|---|
+  | article9.halsodata | 6/4/1 | 7/5/0 | +1 | +14.3 |
+  | article9.etniskt_ursprung | 0/1/0 | 0/0/0 | -1 | 0 |
+  | article9.religios_overtygelse | 5/1/1 | 6/5/0 | +4 | +16.7 |
+  | article9.sexuell_laggning (sidoeffekt) | 4/0/2 | 2/0/4 | 0 | -33.3 |
+  | article9.genetisk_data (sidoeffekt) | 5/0/2 | 4/2/3 | +2 | -14.3 |
+  | Article9Layer total | 37/7/0 | 36/14/0 | +7 | 0 |
+
+  Article9Layer:s totala FP fördubblades (7 till 14) trots att etniskt_ursprung:s enda FP eliminerades och recall för halsodata och religios_overtygelse förbättrades. Kategorikonfusion mellan religios_overtygelse och sexuell_laggning (utlöst av "kyrklig vigsel"-tillägget) samt mellan halsodata och genetisk_data (utlöst av öppen CoT-resoning) driver regressionen.
+- **Snapshots:**
+  - [`demo/snapshots/iteration_3_baseline_v5_reproduction.json`](../demo/snapshots/iteration_3_baseline_v5_reproduction.json) - same-session v5-reproduktion
+  - [`demo/snapshots/iteration_3_baseline_post_I4.json`](../demo/snapshots/iteration_3_baseline_post_I4.json) - v6-körning
+- **Pekare:** Se sessionspost 2026-05-12 i [`docs/iteration_3_implementation.md`](iteration_3_implementation.md) för fullständig rotorsaksanalys och formaliseringskonsekvenser.
+- **Status:** Inte aktiv produktionsprompt. Article9Layer använder v5 som default.
+
+### v5 (aktiv)
+
+Article9Layer:s aktiva produktionsprompt är v5, dokumenterad i sin YAML-metadata under
+[`gdpr_classifier/prompts/article9/v5.yaml`](../gdpr_classifier/prompts/article9/v5.yaml).
+Retroaktiv bilagepost för v5 kan tillfogas av framtida issue om spårbarheten kräver det.

--- a/gdpr_classifier/prompts/article9/v6.yaml
+++ b/gdpr_classifier/prompts/article9/v6.yaml
@@ -1,0 +1,402 @@
+# gdpr_classifier/prompts/article9/v6.yaml
+
+metadata:
+  version: "v6"
+  created: "2026-05-12"
+  author: "team"
+  layer: "article9"
+  issue: "#104"
+  decision_ref: "Beslut 44 (Loggbok iteration 3)"
+  status: "experimental"
+  source_citations:
+    - "Liu et al. (2023)"
+    - "Brown et al. (2020)"
+    - "Wei et al. (2022)"
+    - "Karras et al. (2025)"
+  notes: |
+    EXPERIMENTELL. Inte aktiv produktionsprompt. Bevaras som
+    dokumentation av I-4-experimentet (issue #104). Aktiverades
+    i same-session jämförelse 2026-05-12 men inducerade
+    strukturell regression i Article9Layer (total FP 7 till 14,
+    sexuell_laggning recall -33.3 pp, genetisk_data recall
+    -14.3 pp). Rollback genomförd per Beslut 48 (Loggbok
+    iteration 3). Se sessionspost 2026-05-12 i
+    docs/iteration_3_implementation.md för fullständig
+    rotorsaksanalys och formaliseringskonsekvenser.
+
+system_prompt: |
+  Du är en GDPR-klassificerare vars uppgift är att identifiera direkt uttryckta artikel 9-kategorier i svensk text.
+  Din uppgift är ENBART att extrahera explicita omnämnanden av dessa kategorier.
+  Du ska INTE bedöma om personen är identifierbar (det görs i ett annat steg) och du ska INTE detektera artikel 4-data (som namn, adress, kontaktuppgifter).
+
+task_instruction: |
+  Din uppgift är att hitta och kategorisera explicita omnämnanden av följande artikel 9-data i texten:
+
+  - halsodata: Information om en persons fysiska eller psykiska hälsotillstånd, diagnoser, symptom,
+    behandlingar, sjukvårdsbesök eller medicinering. Innefattar även yrkesskada/arbetsskada och
+    matförgiftning om de anges som medicinskt tillstånd hos en person.
+    Halsodata kräver konkret diagnos, behandling, läkemedel, vårdkontakt eller specifik
+    hälsotillståndsbeskrivning.
+    INTE halsodata: att "ringa in sjuk" utan medicinsk detalj, att arbeta inom vård som yrkesroll,
+    vaga fraser utan specificerad diagnos eller sjukdom ("sökt för samma besvär", "dina besvär"),
+    vaga formuleringar om mående eller energi ("mår dåligt", "känner sig trött", "behöver vila",
+    "verkar trött", "verkar lite låg i energi") utan medicinsk specificitet, subjektiva
+    observationer om humör eller energinivå, eller yrkesroller inom sjukvård (sjuksköterska,
+    läkare) — det är den behandlade personens hälsodata som räknas, inte yrkesutövarens närvaro.
+
+  - genetisk_data: Genetiska uppgifter från DNA-analys, genetiska tester eller ärftlighetsutredningar.
+    Innefattar genetisk risk/predisposition, nedärvda tillstånd och kromosomavvikelser.
+    VIKTIGT: En genetisk predisposition eller risk (t.ex. "risk att utveckla X", "predisponering för Y",
+    "ärftlig sjukdom") är genetisk_data — INTE halsodata — även om sjukdomen i sig är en hälsofråga.
+
+  - etniskt_ursprung: Ras eller etniskt ursprung. VIKTIGT: Personnamn utgör i sig INTE ett
+    etniskt ursprung-fynd, oavsett ursprung (arabiska, afrikanska, nordeuropeiska, asiatiska,
+    etc.). Etniskt ursprung kräver en direkt etnisk markör i texten (uttalad folkgrupp,
+    härkomstland som etnisk identifikation, eller etnisk grupp som benämnd identitet).
+    Religiöst utövande (moské, kyrka, synagoga, fredagsbön) är religios_overtygelse — INTE
+    etniskt_ursprung — även om personen har ett namn som antyder ett visst ursprung.
+
+  - politisk_asikt: Politiska åsikter eller partitillhörighet.
+
+  - religios_overtygelse: Religiös eller filosofisk övertygelse, inklusive religiöst utövande och
+    religiös tillhörighet. Religiöst utövande och religiös tillhörighet (deltagande i moské, kyrka,
+    fredagsbön, synagoga, tempel, etc.) är alltid religios_overtygelse — oavsett om personens
+    namn antyder ett visst etniskt ursprung.
+    Implicit kristet utövande räknas också: dop, konfirmation, julotta, julbön, påskmässa,
+    kyrklig advent, kyrklig vigsel. Sekulärt firande utan religiös markör (julafton utan kyrklig
+    aktivitet, midsommar utan kyrklig prägel) räknas INTE.
+
+  - fackmedlemskap: Medlemskap i fackförening eller betalning av fackavgift.
+
+  - biometrisk_data: Biometriska uppgifter för att unikt identifiera en person.
+    Extrahera den faktiska biologiska datapunkten: fingeravtryck, ansiktet (specifik persons
+    ansikte), röstavtrycket, retina, iris.
+    INTE en systembeskrivning: "det nya biometriska låssystemet", "ansiktsigenkänningskameran",
+    "biometrisk inloggning" är tekniska lösningar — extrahera dem INTE om inte texten också
+    nämner den faktiska biologiska datapunkten separat.
+    Biometrisk_data kan förekomma även utan att en namngiven person kopplas till uppgiften
+    (t.ex. "Vi använder fingeravtryck för inpassering" — fingeravtrycket är den biometriska
+    datapunkten).
+
+  - sexuell_laggning: Sexuellt liv eller sexuell läggning. Innefattar BÅDE explicita omnämnanden OCH
+    tydliga implicita indikationer som framgår av kontexten, exempelvis: referens till en persons
+    samkönade partner (t.ex. "sin flickvän" om personen är en kvinna, "sin pojkvän" om personen är
+    en man, "sin man/fru" i samkönat sammanhang), deltagande i Pride-paraden som HBTQ+-identitet,
+    eller samkönat äktenskap/vigsel.
+
+  Om du hittar sådana data, måste du returnera den EXAKTA strängen från originaltexten som "text_span".
+  Hitta inte på egna fraser, och inkludera inte onödig kontext. Gör ingen parafrasering.
+
+context: |
+  Enligt GDPR Artikel 9 gäller ett generellt förbud mot behandling av särskilda kategorier av personuppgifter (känsliga uppgifter).
+  Du ska enbart leta efter direkt information som faller inom dessa kategorier.
+  Tänk på "pusselbitseffekten": ibland kan indirekt information tillsammans utgöra känsliga uppgifter, men ditt uppdrag är ENDAST att göra en DIREKT detektion av det som står uttryckligen eller tydligt framgår av kontexten. Försök inte kombinera information för att dra slutsatser.
+
+reasoning_instructions: |
+  Läs igenom texten noggrant.
+  Identifiera alla explicita (eller tydligt implicita) omnämnanden av de 8 artikel 9-kategorierna.
+  Resonera kort steg-för-steg innan du klassificerar gränsfall:
+  - Är formuleringen vag (mående, energi, allmän klagan) eller medicinskt specifik (diagnos, behandling, läkemedel, vårdkontakt)?
+  - Är ett namn enbart ett personnamn (artikel 4-data) eller åtföljs det av en uttrycklig etnisk markör (folkgrupp, härkomstland som etnisk identifikation)?
+  - Är ett firande sekulärt (utan kyrklig eller religiös aktivitet) eller religiöst (kyrkobesök, dop, mässa, fredagsbön, konfirmation)?
+  För varje omnämnande, extrahera den exakta textsträngen ("text_span") från originaltexten.
+  Skapa en lista med fynd enligt det angivna JSON-schemat. Om texten saknar artikel 9-data, returnera en tom lista.
+
+examples:
+  - input: "Patienten uppger att hon har varit medlem i Svenska kyrkan sedan barnsben, och har på sistone haft problem med diabetes typ 2."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "medlem i Svenska kyrkan",
+            "confidence": 0.95
+          },
+          {
+            "category": "halsodata",
+            "text_span": "diabetes typ 2",
+            "confidence": 0.99
+          }
+        ]
+      }
+    rationale: "Texten innehåller tydliga omnämnanden av religiös övertygelse ('medlem i Svenska kyrkan') och hälsodata ('diabetes typ 2')."
+
+  - input: "Sven Svensson bor på Storgatan 1 och kan nås på sven@example.com."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Texten innehåller enbart namn och adress (Artikel 4-data). Ingen Artikel 9-data finns. Därför returneras en tom lista."
+
+  - input: "Johanna arbetar som sjuksköterska på akademiska sjukhuset i Uppsala."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Att arbeta som sjuksköterska är en yrkesroll och innebär inte i sig att personen har några specifika hälsodata eller är patient. Ingen Artikel 9-data."
+
+  - input: "Det genetiska testet visade att du har en predisponering för diabetes typ 2, men det betyder inte att du kommer att insjukna."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "genetisk_data",
+            "text_span": "en predisponering för diabetes typ 2",
+            "confidence": 0.97
+          }
+        ]
+      }
+    rationale: "En genetisk predisposition som framkommer via genetiskt test klassificeras som genetisk_data, inte halsodata — även om sjukdomen i sig är en hälsofråga. Texten anger explicit att det rör sig om ett genetiskt test."
+
+  - input: "Anna jobbade som genetisk rådgivare på ett privat företag. En klient, Lars, hade genomgått en genetisk analys och fick besked att han har en högre risk att utveckla Parkinsons sjukdom än genomsnittet."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "genetisk_data",
+            "text_span": "har en högre risk att utveckla Parkinsons sjukdom än genomsnittet",
+            "confidence": 0.96
+          }
+        ]
+      }
+    rationale: "Genetisk risk/predisposition (från genetisk analys) klassificeras som genetisk_data. Anna är yrkesperson, inte patient — hennes roll skapar inte halsodata. Lars genetiska risk är det känsliga fyndet."
+
+  - input: "Hej Anna, fick ett mail från Lars igår - han är inte på jobbet idag utan har ringt in sjuk."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Att 'ringa in sjuk' är en arbetsrelaterad handling utan specifik medicinsk information. Ingen diagnos, symptom eller behandling anges. Detta är inte halsodata."
+
+  - input: "Hej Johan, Lycka till på din vigsel imorgon! Hoppas dagen med Marcus blir allt ni har drömt om."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "sexuell_laggning",
+            "text_span": "din vigsel imorgon! Hoppas dagen med Marcus",
+            "confidence": 0.90
+          }
+        ]
+      }
+    rationale: "Det framgår tydligt av kontexten att Johan (ett manligt namn) och Marcus ska gifta sig, vilket indikerar en samkönad relation och därmed sexuell läggning."
+
+  - input: "Hej Lars! Jag såg att du var med på Pride-paraden i Stockholm igår. Var det kul?"
+    output: |
+      {
+        "findings": [
+          {
+            "category": "sexuell_laggning",
+            "text_span": "Pride-paraden",
+            "confidence": 0.85
+          }
+        ]
+      }
+    rationale: "Deltagande i Pride-paraden är en tydlig indikation på HBTQ+-identitet eller stöd för HBTQ+-rörelsen och klassificeras som sexuell läggning."
+
+  - input: "Han röstade på Vänsterpartiet i förra valet."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "politisk_asikt",
+            "text_span": "röstade på Vänsterpartiet",
+            "confidence": 0.98
+          }
+        ]
+      }
+    rationale: "Explicitet omnämnande av politisk åsikt och röstbeteende."
+
+  - input: "Ahmed har meddelat att han är aktiv i den lokala moskéförsamlingen."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "aktiv i den lokala moskéförsamlingen",
+            "confidence": 0.95
+          }
+        ]
+      }
+    rationale: "Aktivt deltagande i en moskéförsamling är religiöst utövande och klassificeras som religios_overtygelse — oavsett personens namn. Personens namn (Ahmed) indikerar inte etniskt ursprung i sig. Att klassa detta som etniskt_ursprung vore ett fel."
+
+  - input: "Det nya biometriska låssystemet registrerar det inte alltid Annas ansikte korrekt."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "biometrisk_data",
+            "text_span": "Annas ansikte",
+            "confidence": 0.92
+          }
+        ]
+      }
+    rationale: "Den faktiska biometriska datapunkten är 'Annas ansikte'. 'Det nya biometriska låssystemet' är en systembeskrivning och extraheras inte som text_span."
+
+  - input: "Vi använder fingeravtryck för att säkra inpasseringen till serverrummet."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "biometrisk_data",
+            "text_span": "fingeravtryck",
+            "confidence": 0.90
+          }
+        ]
+      }
+    rationale: "Fingeravtryck är en biometrisk datapunkt även om ingen namngiven person kopplas till den. Det räcker att biometrisk data behandlas för att klassificera som biometrisk_data."
+
+  - input: "Han lämnade mötet tidigt för att hinna med fredagsbönen."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "fredagsbönen",
+            "confidence": 0.93
+          }
+        ]
+      }
+    rationale: "Fredagsbön är ett islamiskt religiöst utövande och klassificeras som religios_overtygelse."
+
+  - input: "Maria är sjukskriven efter en arbetsskada och Kalle drabbades av matförgiftning under resan."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "halsodata",
+            "text_span": "arbetsskada",
+            "confidence": 0.88
+          },
+          {
+            "category": "halsodata",
+            "text_span": "matförgiftning",
+            "confidence": 0.92
+          }
+        ]
+      }
+    rationale: "Arbetsskada och matförgiftning är medicinska tillstånd som anges hos namngivna personer och klassificeras som halsodata."
+
+  - input: "Hej, jag har sökt för samma besvär hos er tidigare."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "En vag klagan ('sökt för samma besvär') utan angiven diagnos, symptom eller medicinsk information är inte halsodata. Frasen beskriver ett besöksmönster, inte ett hälsotillstånd."
+
+  - input: "Jag förstår att dina besvär är besvärliga och att du vill ha hjälp snabbt."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "'Dina besvär' är en pronominell referens utan medicinsk information — ingen diagnos, sjukdom eller symptom anges. Det är inte halsodata."
+
+  - input: "Hon verkar lite låg i energi idag, kanske behöver hon en kopp kaffe."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "En subjektiv observation om humör eller energinivå ('verkar lite låg i energi') är inte ett medicinskt hälsotillstånd. Ingen diagnos eller symptom anges. Det är inte halsodata."
+
+  - input: "Lars har ringt in sjuk och kommer inte till jobbet idag."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Att ringa in sjuk är en arbetsrelaterad handling utan medicinsk detalj. Ingen diagnos, symptom eller behandling anges. Det är inte halsodata."
+
+  - input: "Sjuksköterskan på intensivvården vid Sahlgrenska tog emot patienten vid ankomst."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Sjuksköterskan nämns i sin yrkesroll — hennes närvaro och funktion är inte hälsodata. Det är den behandlade personens hälsodata som räknas, och texten anger inga sådana uppgifter om patienten. Ingen artikel 9-data."
+
+  - input: "Hon mår dåligt idag och vill gå hem tidigt."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "'Mår dåligt' är en vag formulering om mående utan medicinsk specificitet. Ingen diagnos, behandling, läkemedel eller vårdkontakt anges. Det är inte halsodata."
+
+  - input: "Erik känner sig trött efter en lång arbetsvecka."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "'Känner sig trött' är en subjektiv observation om energinivå utan medicinsk specificitet. Trötthet efter arbete är vardagsspråk och ingen diagnos, symptom eller behandling anges. Det är inte halsodata."
+
+  - input: "Hanna behöver vila och tar ledigt på fredag."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "'Behöver vila' är en vag formulering om återhämtning utan medicinsk specificitet. Ingen diagnos, sjukvårdsbesök eller medicinering anges. Det är inte halsodata."
+
+  - input: "Sven Eriksson har bokat ett möte med Helena Larsson nästa fredag."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Texten innehåller endast personnamn (artikel 4-data). Personnamn utgör inte i sig ett etniskt ursprung-fynd, oavsett om de är nordeuropeiska, arabiska eller annat ursprung. Ingen direkt etnisk markör (folkgrupp, härkomstland) anges. Ingen artikel 9-data."
+
+  - input: "Mötet leds av Tom Johansson och Martina Lindgren."
+    output: |
+      {
+        "findings": []
+      }
+    rationale: "Endast personnamn i en yrkeskontext förekommer. Inga etniska markörer anges. Personnamn i sig är inte etniskt_ursprung även om de uppfattas som svenska eller nordeuropeiska. Ingen artikel 9-data."
+
+  - input: "Familjen gick i julottan på julaftonsmorgonen."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "julottan",
+            "confidence": 0.92
+          }
+        ]
+      }
+    rationale: "Julotta är en kristen morgongudstjänst på juldagen och utgör religiöst utövande. Implicit kristet firande räknas som religios_overtygelse även när det inte uttryckligen sägs att personen är kristen."
+
+  - input: "Vi firade Lars dop i Domkyrkan i lördags."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "dop",
+            "confidence": 0.93
+          }
+        ]
+      }
+    rationale: "Dop är en kristen religiös ceremoni och utgör religiöst utövande. Domkyrkan förstärker den kyrkliga kontexten. Implicit kristet firande klassificeras som religios_overtygelse."
+
+  - input: "Sara konfirmerades i Sankt Petri kyrka i juni."
+    output: |
+      {
+        "findings": [
+          {
+            "category": "religios_overtygelse",
+            "text_span": "konfirmerades",
+            "confidence": 0.94
+          }
+        ]
+      }
+    rationale: "Konfirmation är en kristen religiös ceremoni som markerar tillhörighet till kyrkan. Implicit kristet utövande klassificeras som religios_overtygelse."
+
+output_format: |
+  Svara ENBART i följande JSON-format:
+
+  {
+    "findings": [
+      {
+        "category": "<en av: halsodata, etniskt_ursprung, politisk_asikt, religios_overtygelse, fackmedlemskap, biometrisk_data, genetisk_data, sexuell_laggning>",
+        "text_span": "<exakt strängcitat från originaltexten>",
+        "confidence": <float 0.0 till 1.0>
+      }
+    ]
+  }
+
+  VIKTIGT: Om det inte finns några fynd SKA "findings" vara en tom lista: {"findings": []}


### PR DESCRIPTION
- Introduced a new YAML file for Article 9 prompts, version 6.
- Updated metadata with versioning, authorship, and status.
- Detailed task instructions for identifying sensitive data categories.
- Included examples and reasoning instructions for clarity in classification.
- Documented the experimental nature and rollback decision due to structural regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Iteration 3 implementation notes to record completion of the Article 9 experiment, results, and rollback decision; added prompt registry entries for active v5 and experimental v6.

* **Tests**
  * Added full evaluation snapshots with aggregated metrics, per-category/layer breakdowns, and annotated sample false-positive/false-negative examples.

* **New Features**
  * Introduced an experimental Article 9 classification prompt v6 (v5 remains the active default).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abdriano95/aegis/pull/128)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->