### PR TITLE
I-21 (#142): Demo-dashboard — rapport/analys-fliksuppdelning, snapshot-väljare, version pinning-fix

### DIFF
--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -22,8 +22,14 @@ from gdpr_classifier.layers.combination import CombinationLayer
 from gdpr_classifier.layers.entity import EntityLayer
 from gdpr_classifier.layers.llm.provider import LLMProviderError
 from gdpr_classifier.layers.pattern import PatternLayer
-from demo.layout import _DEMO_TEXTS, freetext_tab_layout
-from demo.snapshot_loader import SnapshotData, load_snapshot
+from demo.layout import _DEMO_TEXTS, analysis_tab_layout, freetext_tab_layout
+from demo.snapshot_loader import (
+    SnapshotData,
+    SnapshotInfo,
+    list_snapshots,
+    load_snapshot,
+    load_snapshot_file,
+)
 
 _LOG = logging.getLogger(__name__)
 
@@ -95,8 +101,16 @@ def _get_snapshot() -> SnapshotData | None:
 
 
 def _make_table(
-    table_id: str, columns: list[dict], data: list[dict]
+    table_id: str,
+    columns: list[dict],
+    data: list[dict],
+    extra_conditional: list[dict] | None = None,
 ) -> dash_table.DataTable:
+    conditional: list[dict] = [
+        {"if": {"row_index": "odd"}, "backgroundColor": "#f9f9f9"},
+    ]
+    if extra_conditional:
+        conditional = conditional + extra_conditional
     return dash_table.DataTable(
         id=table_id,
         columns=columns,
@@ -112,12 +126,7 @@ def _make_table(
             "padding": "8px",
             "minWidth": "80px",
         },
-        style_data_conditional=[
-            {
-                "if": {"row_index": "odd"},
-                "backgroundColor": "#f9f9f9",
-            },
-        ],
+        style_data_conditional=conditional,
     )
 
 
@@ -289,6 +298,303 @@ def _testdata_rows(dataset: list) -> list[dict]:
         }
         for i, item in enumerate(dataset)
     ]
+
+
+# ---------------------------------------------------------------------------
+# Curated metadata row + badges (shared by report & analysis tabs)
+# ---------------------------------------------------------------------------
+
+
+def _meta_mode(meta: dict) -> str:
+    """Aggregator mode, defaulting to 'legacy' for pre-I-7g snapshots."""
+    return meta.get("cross_validation_mode") or meta.get("mode") or "legacy"
+
+
+def _badge(text: str, bg: str) -> html.Span:
+    return html.Span(
+        text,
+        style={
+            "backgroundColor": bg,
+            "color": "white",
+            "fontWeight": "bold",
+            "borderRadius": "4px",
+            "padding": "2px 8px",
+            "marginRight": "8px",
+            "fontSize": "12px",
+        },
+    )
+
+
+def _metadata_row(meta: dict, prefix: str = "") -> html.Div:
+    """Compact curated metadata row: model + mode badges then labelled text.
+
+    Every field is read defensively so older snapshots that lack a field
+    degrade to '?' rather than raising.
+    """
+    mode = _meta_mode(meta)
+    mode_bg = "#27ae60" if mode == "cross_validating" else "#7f8c8d"
+    date = (meta.get("generated_at") or "?")[:10]
+    commit = (meta.get("git_commit") or "?")[:8]
+    subset = meta.get("subset") or "all"
+    texts = (meta.get("dataset") or {}).get("total_texts", "?")
+    pv = meta.get("prompt_versions") or {}
+    children: list = []
+    if prefix:
+        children.append(html.Strong(prefix))
+    children.extend(
+        [
+            _badge(meta.get("model", "?"), "#2c3e50"),
+            _badge(mode, mode_bg),
+            html.Span(
+                f"Datum: {date} · Commit: {commit} · Subset: {subset} · "
+                f"Texter: {texts} · Prompts: article9 {pv.get('article9', '?')}, "
+                f"combination {pv.get('combination', '?')}"
+            ),
+        ]
+    )
+    return html.Div(
+        children,
+        style={"marginBottom": "12px", "fontSize": "13px", "color": "#555"},
+    )
+
+
+def _snapshot_option_label(info: SnapshotInfo) -> str:
+    """Dropdown label: description + filename + model + mode + subset (issue AC)."""
+    m = info.metadata
+    return (
+        f"{info.description} — {info.filename} · "
+        f"{m.get('model', '?')} · {_meta_mode(m)} · {m.get('subset') or 'all'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence basis breakdown (i7d-snapshots only)
+# ---------------------------------------------------------------------------
+
+_EBB_MECHANISMS = (
+    "structural_support",
+    "high_confidence_no_support",
+    "no_support_required",
+)
+
+_EBB_COLUMNS = [
+    {"name": "Mekanism", "id": "mechanism"},
+    {"name": "TP", "id": "tp"},
+    {"name": "FP", "id": "fp"},
+]
+
+
+def _ebb_rows(block: dict) -> list[dict]:
+    rows = []
+    for m in _EBB_MECHANISMS:
+        cell = block.get(m) or {}
+        rows.append(
+            {"mechanism": m, "tp": cell.get("tp", "–"), "fp": cell.get("fp", "–")}
+        )
+    return rows
+
+
+def _evidence_basis_section(
+    ebb: dict | None,
+    heading: str,
+    id_prefix: str,
+) -> list:
+    """Render the evidence-basis breakdown (total + context_kombination_only).
+
+    Returns [] when ``ebb`` is missing/empty (section stays invisible).
+    Falls back to a notice instead of crashing on an unexpected structure.
+    """
+    if not ebb:
+        return []
+    try:
+        children: list = [html.H3(heading)]
+        for key, label in (
+            ("total", "Total"),
+            ("context_kombination_only", "Endast context.kombination"),
+        ):
+            block = ebb.get(key)
+            if not isinstance(block, dict):
+                continue
+            children.append(html.H4(label, style={"marginBottom": "4px"}))
+            children.append(
+                _make_table(f"{id_prefix}-ebb-{key}", _EBB_COLUMNS, _ebb_rows(block))
+            )
+        note = ebb.get("note")
+        if note:
+            children.append(
+                html.P(
+                    note,
+                    style={
+                        "fontSize": "12px",
+                        "color": "#555",
+                        "fontStyle": "italic",
+                    },
+                )
+            )
+        return children
+    except (KeyError, TypeError, AttributeError):
+        return [
+            html.H3(heading),
+            html.P("Evidence basis-data finns men kan inte renderas"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot comparison (analysis tab)
+# ---------------------------------------------------------------------------
+
+_COMPARE_DIMENSION_COLUMNS = [
+    {"name": "Dimension", "id": "dimension"},
+    {"name": "Nivå", "id": "level"},
+    {"name": "A Antal", "id": "a_count"},
+    {"name": "B Antal", "id": "b_count"},
+    {"name": "Δ", "id": "d_count"},
+]
+
+
+def _compare_columns(level_name: str) -> list[dict]:
+    cols = [{"name": level_name, "id": "level"}]
+    for side in ("A", "B"):
+        for f in ("TP", "FP", "FN", "P", "R", "F1"):
+            cols.append({"name": f"{side} {f}", "id": f"{side.lower()}_{f.lower()}"})
+    for f in ("P", "R", "F1"):
+        cols.append({"name": f"Δ {f}", "id": f"d_{f.lower()}"})
+    return cols
+
+
+def _fmt_pct(x) -> str:
+    return f"{x:.2%}" if isinstance(x, (int, float)) else "–"
+
+
+def _delta_pp(a, b) -> str:
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return f"{(b - a) * 100:+.1f} pp"
+    return "—"
+
+
+def _compare_metric_row(level: str, a, b, *, suppress_rf: bool = False) -> dict:
+    """One comparison row for a pair of optional RunMetrics (A vs B).
+
+    ``suppress_rf`` mirrors the report tab's per-layer convention where
+    recall/F1 are not meaningful (cross-layer FN attribution) → shown N/A.
+    """
+    row: dict = {"level": level}
+    for side, m in (("a", a), ("b", b)):
+        if m is None:
+            for k in ("tp", "fp", "fn", "p", "r", "f1"):
+                row[f"{side}_{k}"] = "–"
+            continue
+        row[f"{side}_tp"] = m.tp
+        row[f"{side}_fp"] = m.fp
+        row[f"{side}_fn"] = m.fn
+        row[f"{side}_p"] = _fmt_pct(m.precision)
+        row[f"{side}_r"] = "N/A" if suppress_rf else _fmt_pct(m.recall)
+        row[f"{side}_f1"] = "N/A" if suppress_rf else _fmt_pct(m.f1)
+    row["d_p"] = _delta_pp(
+        a.precision if a else None, b.precision if b else None
+    )
+    if suppress_rf:
+        row["d_r"] = row["d_f1"] = "—"
+    else:
+        row["d_r"] = _delta_pp(a.recall if a else None, b.recall if b else None)
+        row["d_f1"] = _delta_pp(a.f1 if a else None, b.f1 if b else None)
+    return row
+
+
+def _compare_total_rows(a_rep, b_rep) -> list[dict]:
+    return [_compare_metric_row("Totalt", a_rep.total, b_rep.total)]
+
+
+def _compare_category_rows(a_rep, b_rep) -> list[dict]:
+    cats = sorted(
+        set(a_rep.per_category) | set(b_rep.per_category), key=lambda c: c.value
+    )
+    return [
+        _compare_metric_row(
+            c.value, a_rep.per_category.get(c), b_rep.per_category.get(c)
+        )
+        for c in cats
+    ]
+
+
+def _compare_layer_rows(a_rep, b_rep) -> list[dict]:
+    layers = sorted(set(a_rep.per_layer) | set(b_rep.per_layer))
+    return [
+        _compare_metric_row(
+            layer,
+            a_rep.per_layer.get(layer),
+            b_rep.per_layer.get(layer),
+            suppress_rf=True,
+        )
+        for layer in layers
+    ]
+
+
+_DIMENSION_SPEC = [
+    ("Identifiability", "NONE", "identifiability_none"),
+    ("Identifiability", "INDIRECT", "identifiability_indirect"),
+    ("Identifiability", "DIRECT", "identifiability_direct"),
+    ("Data class", "NONE", "data_class_none"),
+    ("Data class", "SPECIAL", "data_class_special"),
+    ("Data class", "CRIMINAL", "data_class_criminal"),
+]
+
+
+def _dimension_is_empty(stats) -> bool:
+    return all(getattr(stats, attr) == 0 for _, _, attr in _DIMENSION_SPEC)
+
+
+def _compare_dimension_rows(a_rep, b_rep) -> list[dict]:
+    a, b = a_rep.per_dimension, b_rep.per_dimension
+    rows = []
+    for dim, lvl, attr in _DIMENSION_SPEC:
+        av, bv = getattr(a, attr), getattr(b, attr)
+        rows.append(
+            {
+                "dimension": dim,
+                "level": lvl,
+                "a_count": av,
+                "b_count": bv,
+                "d_count": f"{bv - av:+d}",
+            }
+        )
+    return rows
+
+
+def _delta_conditional(col_ids: list[str]) -> list[dict]:
+    """Green for improvements (+), red for regressions (-); neutral otherwise."""
+    rules: list[dict] = []
+    for cid in col_ids:
+        rules.append(
+            {
+                "if": {"filter_query": f'{{{cid}}} contains "-"', "column_id": cid},
+                "color": "#c0392b",
+                "fontWeight": "bold",
+            }
+        )
+        rules.append(
+            {
+                "if": {"filter_query": f'{{{cid}}} contains "+"', "column_id": cid},
+                "color": "#1e8449",
+                "fontWeight": "bold",
+            }
+        )
+    return rules
+
+
+def _side_by_side(left, right) -> html.Div:
+    """Two equal-width columns that wrap to two stacked rows on narrow viewports.
+
+    ``left``/``right`` may be a single component or a list of components.
+    """
+    col_style = {"flex": "1", "minWidth": "300px"}
+    return html.Div(
+        [
+            html.Div(left, style=col_style),
+            html.Div(right, style=col_style),
+        ],
+        style={"display": "flex", "gap": "16px", "flexWrap": "wrap"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -705,6 +1011,12 @@ def render_tab(tab: str) -> html.Div:
                 html.Div(id="report-content"),
             ],
         )
+    if tab == "tab-analysis":
+        options = [
+            {"label": _snapshot_option_label(info), "value": info.filename}
+            for info in list_snapshots()
+        ]
+        return analysis_tab_layout(options)
     if tab == "tab-testdata":
         try:
             d1 = load_dataset(str(_DATASET_PATHS["iteration_1"]))
@@ -759,17 +1071,8 @@ def update_report(verbose_values: list[str]) -> list:
     meta = snapshot.metadata
     verbose = "verbose" in (verbose_values or [])
 
-    ds = meta.get("dataset", {})
-    meta_div = html.Div(
-        f"Snapshot genererad: {meta.get('generated_at', '?')[:10]}, "
-        f"modell: {meta.get('model', '?')}, "
-        f"dataset: {ds.get('total_texts', '?')} texter, "
-        f"commit: {meta.get('git_commit', '?')[:8]}",
-        style={"marginBottom": "16px", "fontSize": "13px", "color": "#555"},
-    )
-
     children: list = [
-        meta_div,
+        _metadata_row(meta),
         html.H3("Totala mätvärden"),
         _make_table("total-table", _TOTAL_COLUMNS, _total_rows(report)),
         html.H3("Per kategori"),
@@ -779,6 +1082,13 @@ def update_report(verbose_values: list[str]) -> list:
         html.H3("Per dimension"),
         _make_table("dimension-table", _DIMENSION_COLUMNS, _dimension_rows(report.per_dimension)),
     ]
+    children.extend(
+        _evidence_basis_section(
+            snapshot.evidence_basis_breakdown,
+            "Evidence basis (cross-validating-mekanismer)",
+            id_prefix="report",
+        )
+    )
 
     if verbose:
         fp_data = _fp_rows(report)
@@ -798,6 +1108,125 @@ def update_report(verbose_values: list[str]) -> list:
                     else html.P("Inga false negatives.")
                 ),
             ],
+        )
+
+    return children
+
+
+_DELTA_METRIC_COLS = ["d_p", "d_r", "d_f1"]
+
+
+def _comparison_level(
+    level: str, a_rep, b_rep
+) -> list:
+    """Render one comparison level, or a 'data saknas' notice if absent in both."""
+    if level == "total":
+        return [
+            html.H3("Total"),
+            _make_table(
+                "cmp-total",
+                _compare_columns("Metric"),
+                _compare_total_rows(a_rep, b_rep),
+                extra_conditional=_delta_conditional(_DELTA_METRIC_COLS),
+            ),
+        ]
+    if level == "category":
+        if not a_rep.per_category or not b_rep.per_category:
+            return [html.H3("Per kategori"), html.P("Data saknas för denna nivå")]
+        return [
+            html.H3("Per kategori"),
+            _make_table(
+                "cmp-category",
+                _compare_columns("Kategori"),
+                _compare_category_rows(a_rep, b_rep),
+                extra_conditional=_delta_conditional(_DELTA_METRIC_COLS),
+            ),
+        ]
+    if level == "layer":
+        if not a_rep.per_layer or not b_rep.per_layer:
+            return [html.H3("Per lager"), html.P("Data saknas för denna nivå")]
+        return [
+            html.H3("Per lager"),
+            _make_table(
+                "cmp-layer",
+                _compare_columns("Lager"),
+                _compare_layer_rows(a_rep, b_rep),
+                extra_conditional=_delta_conditional(["d_p"]),
+            ),
+        ]
+    if level == "dimension":
+        if _dimension_is_empty(a_rep.per_dimension) or _dimension_is_empty(
+            b_rep.per_dimension
+        ):
+            return [html.H3("Per dimension"), html.P("Data saknas för denna nivå")]
+        return [
+            html.H3("Per dimension"),
+            _make_table(
+                "cmp-dimension",
+                _COMPARE_DIMENSION_COLUMNS,
+                _compare_dimension_rows(a_rep, b_rep),
+                extra_conditional=_delta_conditional(["d_count"]),
+            ),
+        ]
+    return []
+
+
+@callback(
+    Output("analysis-content", "children"),
+    Input("snapshot-a", "value"),
+    Input("snapshot-b", "value"),
+    Input("analysis-levels", "value"),
+)
+def update_analysis(
+    file_a: str | None, file_b: str | None, levels: list[str] | None
+) -> list:
+    """Render the A/B snapshot comparison for the selected levels."""
+    if not file_a or not file_b:
+        return [html.P("Välj snapshot A och B för att jämföra.")]
+
+    infos = {info.filename: info for info in list_snapshots()}
+    info_a, info_b = infos.get(file_a), infos.get(file_b)
+    if info_a is None or info_b is None:
+        return [html.P("En av de valda snapshotsen kunde inte hittas.")]
+
+    data_a = load_snapshot_file(info_a.path)
+    data_b = load_snapshot_file(info_b.path)
+    if data_a is None or data_b is None:
+        return [html.P("En av de valda snapshotsen kunde inte laddas.")]
+
+    children: list = [
+        _side_by_side(
+            _metadata_row(data_a.metadata, prefix="A: "),
+            _metadata_row(data_b.metadata, prefix="B: "),
+        ),
+    ]
+
+    selected = levels or []
+    for level in ("total", "category", "layer", "dimension"):
+        if level in selected:
+            children.extend(_comparison_level(level, data_a.report, data_b.report))
+
+    ebb_a, ebb_b = data_a.evidence_basis_breakdown, data_b.evidence_basis_breakdown
+    if ebb_a and ebb_b:
+        children.append(
+            _side_by_side(
+                _evidence_basis_section(ebb_a, "A: Evidence basis", id_prefix="a"),
+                _evidence_basis_section(ebb_b, "B: Evidence basis", id_prefix="b"),
+            )
+        )
+    elif ebb_a:
+        children.extend(
+            _evidence_basis_section(ebb_a, "A: Evidence basis", id_prefix="a")
+        )
+        children.append(
+            html.P(f"Snapshot B ({file_b}) saknar evidence_basis_breakdown")
+        )
+    elif ebb_b:
+        children.extend(
+            _evidence_basis_section(ebb_b, "B: Evidence basis", id_prefix="b")
+        )
+        children.append(
+            html.P(f"Snapshot A ({file_a}) saknar evidence_basis_breakdown")
         )
 
     return children

--- a/demo/layout.py
+++ b/demo/layout.py
@@ -88,8 +88,58 @@ def freetext_tab_layout() -> html.Div:
     )
 
 
+_LEVEL_OPTIONS = [
+    {"label": " Total", "value": "total"},
+    {"label": " Per kategori", "value": "category"},
+    {"label": " Per lager", "value": "layer"},
+    {"label": " Per dimension", "value": "dimension"},
+]
+
+
+def analysis_tab_layout(snapshot_options: list[dict]) -> html.Div:
+    """Return the layout for the Analys tab (snapshot comparison).
+
+    ``snapshot_options`` is a list of ``{"label", "value"}`` dicts built by
+    the caller from a fresh ``list_snapshots()`` scan so the dropdowns never
+    go stale between tab visits.
+    """
+    _dd_style = {"marginBottom": "12px", "fontSize": "13px"}
+    return html.Div(
+        [
+            html.H2("Analys"),
+            html.Div(
+                "Jämför två snapshots: välj A och B nedan. Δ-kolumnerna "
+                "visar B − A i procentenheter (grönt = förbättring).",
+                style={"marginBottom": "12px", "fontSize": "13px", "color": "#555"},
+            ),
+            html.Label("Snapshot A", style={"fontWeight": "bold"}),
+            dcc.Dropdown(
+                id="snapshot-a",
+                options=snapshot_options,
+                placeholder="Välj snapshot A",
+                style=_dd_style,
+            ),
+            html.Label("Snapshot B", style={"fontWeight": "bold"}),
+            dcc.Dropdown(
+                id="snapshot-b",
+                options=snapshot_options,
+                placeholder="Välj snapshot B",
+                style=_dd_style,
+            ),
+            html.Label("Nivåer", style={"fontWeight": "bold"}),
+            dcc.Checklist(
+                id="analysis-levels",
+                options=_LEVEL_OPTIONS,
+                value=["total", "category"],
+                style={"marginBottom": "16px"},
+            ),
+            html.Div(id="analysis-content"),
+        ],
+    )
+
+
 def get_layout() -> html.Div:
-    """Return the top-level Dash layout with three tabs: report, freetext, and testdata."""
+    """Return the top-level Dash layout: report, analysis, freetext, testdata."""
     return html.Div(
         children=[
             html.H1("GDPR-classifier - Demo", style={"textAlign": "center"}),
@@ -98,6 +148,7 @@ def get_layout() -> html.Div:
                 value="tab-report",
                 children=[
                     dcc.Tab(label="Utvärderingsrapport", value="tab-report"),
+                    dcc.Tab(label="Analys", value="tab-analysis"),
                     dcc.Tab(label="Fritext-analys", value="tab-freetext"),
                     dcc.Tab(label="Testdata", value="tab-testdata"),
                 ],

--- a/demo/snapshot_descriptions.py
+++ b/demo/snapshot_descriptions.py
@@ -1,0 +1,62 @@
+"""Curated one-line Swedish descriptions per snapshot filename.
+
+Kept in a dedicated module so the description catalogue can be maintained
+independently of loading/rendering logic. Filenames not present in the dict
+fall back to ``"<filnamn> (ingen beskrivning)"`` — never raises.
+"""
+
+from __future__ import annotations
+
+SNAPSHOT_DESCRIPTIONS: dict[str, str] = {
+    "i7d_cross_validating.json":
+        "Iteration 3 — post-I-7g produktionsmätning (qwen3:14b, cross-validating, F1 86.94%); rapportflikens nya källa",
+    "i7d_cross_validating_opus47.json":
+        "Iteration 3 — post-I-7g med Claude Opus 4.7 som molnprovider, cross-validating (F1 87.85%, providerjämförelse)",
+    "i7d_cross_validating_pre_i7e.json":
+        "Iteration 3 — cross-validating före I-7e:s deduplicated_sources (qwen2.5:7b, F1 82.33%)",
+    "i7d_cross_validating_qwen25_baseline.json":
+        "Iteration 3 — post-I-7g cross-validating med qwen2.5:7b som modelljämförelse mot qwen3:14b (F1 82.33%)",
+    "i7d_legacy.json":
+        "Iteration 3 — post-I-7g i legacy-läge (qwen3:14b, F1 86.94%); baslinjejämförelse mot cross-validating",
+    "i7d_legacy_opus47.json":
+        "Iteration 3 — post-I-7g legacy-läge med Claude Opus 4.7 (F1 87.85%, providerjämförelse)",
+    "i7d_legacy_pre_i7e.json":
+        "Iteration 3 — legacy-läge före I-7e:s deduplicated_sources (qwen2.5:7b, F1 82.33%)",
+    "i7d_legacy_qwen25_baseline.json":
+        "Iteration 3 — post-I-7g legacy-läge med qwen2.5:7b som modelljämförelse (F1 82.33%)",
+    "iteration_2_report.json":
+        "Iteration 2 — slutmätning (qwen2.5:7b, combination v4, F1 74.55%); historisk baslinje",
+    "iteration_3_baseline_post_I1.json":
+        "Iteration 3 — efter I-1 (prompt-skärpning context.yrke/organisation, F1 79.33%)",
+    "iteration_3_baseline_post_I2.json":
+        "Iteration 3 — efter I-2 (matcher-aliasing article4.adress ↔ context.plats, F1 75.99%)",
+    "iteration_3_baseline_post_I3.json":
+        "Iteration 3 — efter I-3 (aggregator-deduplicering inom samma kategori, F1 78.23%)",
+    "iteration_3_baseline_post_I4.json":
+        "Iteration 3 — efter I-4 med experimentell article9 v6 (regression, rollback per Beslut 48, F1 78.17%)",
+    "iteration_3_baseline_post_I5.json":
+        "Iteration 3 — efter I-5 (tvådimensionell operationalisering identifierbarhet × dataklass, F1 79.48%)",
+    "iteration_3_baseline_v4_reproduction.json":
+        "Iteration 3 — reproduktionstest av combination v4 (qwen2.5:7b, F1 77.49%)",
+    "iteration_3_baseline_v5_reproduction.json":
+        "Iteration 3 — reproduktionstest av combination v5 (qwen2.5:7b, F1 79.26%)",
+    "iteration_3_post_I5_fixup.json":
+        "Iteration 3 — post-I-5-fixup (qwen2.5:7b, F1 79.48%); rapportflikens tidigare källa, ersätts av i7d",
+    "iteration_3_post_num_ctx_fix.json":
+        "Iteration 3 — efter num_ctx-parameterfix (qwen2.5:7b, F1 79.33%)",
+    "iteration_3_probe_qwen25_7b_article9.json":
+        "Iteration 3 — I-7-modellprob: qwen2.5:7b enbart article9-delmängd (52 texter, F1 63.72%)",
+    "iteration_3_probe_qwen25_7b_combination.json":
+        "Iteration 3 — I-7-modellprob: qwen2.5:7b enbart combination-delmängd (27 texter, F1 71.76%)",
+    "iteration_3_probe_qwen3_14b_article9.json":
+        "Iteration 3 — I-7-modellprob: qwen3:14b enbart article9-delmängd (52 texter, F1 73.79%)",
+    "iteration_3_probe_qwen3_14b_combination.json":
+        "Iteration 3 — I-7-modellprob: qwen3:14b enbart combination-delmängd (27 texter, F1 72.59%)",
+    "iteration_3_probe_qwen3_14b_full_pipeline.json":
+        "Iteration 3 — I-7-modellprob: qwen3:14b full pipeline (159 texter, F1 82.31%); motiverade modellbytet",
+}
+
+
+def get_description(filename: str) -> str:
+    """Return the curated description for ``filename`` or a safe fallback."""
+    return SNAPSHOT_DESCRIPTIONS.get(filename, f"{filename} (ingen beskrivning)")

--- a/demo/snapshot_loader.py
+++ b/demo/snapshot_loader.py
@@ -8,41 +8,98 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 
 from evaluation.dataset.labeled_finding import LabeledFinding
 from evaluation.report import DimensionStats, Report, RunMetrics, SampleResult
 from gdpr_classifier.core.category import Category
 from gdpr_classifier.core.finding import Finding
+from demo.snapshot_descriptions import get_description
 
 _LOG = logging.getLogger(__name__)
 
 _SNAPSHOT_PATH = (
-    Path(__file__).resolve().parent / "snapshots" / "iteration_3_post_I5_fixup.json"
+    Path(__file__).resolve().parent / "snapshots" / "i7d_cross_validating.json"
 )
 
 
 @dataclass(frozen=True)
 class SnapshotData:
-    """Container for a loaded and rehydrated evaluation snapshot."""
+    """Container for a loaded and rehydrated evaluation snapshot.
+
+    ``evidence_basis_breakdown`` carries the optional top-level
+    cross-validating mechanism breakdown (present in i7d-snapshots only);
+    it is exposed raw so the report/analysis views can render it.
+    """
 
     metadata: dict
     report: Report
+    evidence_basis_breakdown: dict | None = None
+
+
+@dataclass(frozen=True)
+class SnapshotInfo:
+    """Lightweight catalogue entry for a discoverable snapshot file."""
+
+    filename: str
+    path: Path
+    metadata: dict
+    description: str
 
 
 def load_snapshot() -> SnapshotData | None:
-    """Load the snapshot file and return a rehydrated SnapshotData, or None on failure."""
-    if not _SNAPSHOT_PATH.exists():
-        _LOG.info("Snapshot file not found at %s", _SNAPSHOT_PATH)
+    """Load the default snapshot and return a rehydrated SnapshotData, or None."""
+    return load_snapshot_file(_SNAPSHOT_PATH)
+
+
+def load_snapshot_file(path: Path) -> SnapshotData | None:
+    """Load and rehydrate an arbitrary snapshot file, or None on failure.
+
+    Extra top-level keys (cross_validation_mode, baseline_iteration_2,
+    instrument_fn, sanity_check, llm_failures, ...) are ignored;
+    ``evidence_basis_breakdown`` is captured when present.
+    """
+    if not path.exists():
+        _LOG.info("Snapshot file not found at %s", path)
         return None
     try:
-        raw = json.loads(_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
         report = _rehydrate_report(raw["report"])
-        return SnapshotData(metadata=raw.get("metadata", {}), report=report)
+        return SnapshotData(
+            metadata=raw.get("metadata", {}),
+            report=report,
+            evidence_basis_breakdown=raw.get("evidence_basis_breakdown"),
+        )
     except (json.JSONDecodeError, FileNotFoundError, KeyError, ValueError):
-        _LOG.exception("Failed to load or rehydrate snapshot from %s", _SNAPSHOT_PATH)
+        _LOG.exception("Failed to load or rehydrate snapshot from %s", path)
         return None
+
+
+def list_snapshots() -> list[SnapshotInfo]:
+    """Discover loadable top-level snapshots in the snapshots directory.
+
+    Scans ``*.json`` at the top level only (non-recursive → the
+    ``pre_num_ctx_fix/`` subdirectory and ``.log``/``.gitkeep`` files are
+    excluded). Files that fail to load/rehydrate are skipped with a warning
+    rather than aborting the scan. Sorted by filename.
+    """
+    snapshots_dir = _SNAPSHOT_PATH.parent
+    infos: list[SnapshotInfo] = []
+    for path in sorted(snapshots_dir.glob("*.json")):
+        data = load_snapshot_file(path)
+        if data is None:
+            _LOG.warning("Skipping unloadable snapshot %s", path.name)
+            continue
+        infos.append(
+            SnapshotInfo(
+                filename=path.name,
+                path=path,
+                metadata=data.metadata,
+                description=get_description(path.name),
+            )
+        )
+    return infos
 
 
 def _rehydrate_report(data: dict) -> Report:
@@ -51,6 +108,12 @@ def _rehydrate_report(data: dict) -> Report:
     Iteration 2-snapshot innehåller en ``per_mechanism``-nyckel som hörde
     till en tidigare modell (MechanismStats borttagen i fixup av Beslut 49
     reviderad). Nyckeln ignoreras tyst om den finns.
+
+    Pre-I-5-snapshots bär ett äldre ``per_dimension``-schema
+    (identifiability_low/medium/high, data_class_ordinary). Ett
+    inkompatibelt schema degraderas tyst till tom DimensionStats — vi
+    fabricerar inte värden — så att övriga nivåer ändå kan jämföras och
+    analysvyn visar "Data saknas för denna nivå".
     """
     total = RunMetrics(**data["total"])
     per_category = {
@@ -60,7 +123,11 @@ def _rehydrate_report(data: dict) -> Report:
     per_layer = {k: RunMetrics(**v) for k, v in data["per_layer"].items()}
     samples = [_rehydrate_sample(s) for s in data.get("samples", [])]
     pd_data = data.get("per_dimension", {})
-    per_dimension = DimensionStats(**pd_data) if pd_data else DimensionStats()
+    _dim_fields = {f.name for f in fields(DimensionStats)}
+    if pd_data and set(pd_data).issubset(_dim_fields):
+        per_dimension = DimensionStats(**pd_data)
+    else:
+        per_dimension = DimensionStats()
     return Report(
         total=total,
         per_category=per_category,

--- a/demo/snapshot_loader.py
+++ b/demo/snapshot_loader.py
@@ -60,7 +60,7 @@ def load_snapshot_file(path: Path) -> SnapshotData | None:
     instrument_fn, sanity_check, llm_failures, ...) are ignored;
     ``evidence_basis_breakdown`` is captured when present.
     """
-    if not path.exists():
+    if not path.is_file():
         _LOG.info("Snapshot file not found at %s", path)
         return None
     try:
@@ -71,7 +71,10 @@ def load_snapshot_file(path: Path) -> SnapshotData | None:
             report=report,
             evidence_basis_breakdown=raw.get("evidence_basis_breakdown"),
         )
-    except (json.JSONDecodeError, FileNotFoundError, KeyError, ValueError):
+    except (json.JSONDecodeError, OSError, KeyError, TypeError, ValueError):
+        # Any malformed/unreadable snapshot degrades to None so a single bad
+        # file never aborts list_snapshots() (covers I/O errors from
+        # read_text and TypeErrors from schema drift in _rehydrate_report).
         _LOG.exception("Failed to load or rehydrate snapshot from %s", path)
         return None
 

--- a/docs/iteration_3_implementation.md
+++ b/docs/iteration_3_implementation.md
@@ -142,7 +142,7 @@ Status-legenda: ✅ Klar | 🔄 Pågår | ⏸️ Blockerad | ⬜ Ej startad
 | [#118](https://github.com/Abdriano95/aegis/issues/118) (I-18) | Iteration 3:s naturalistiska utvärdering med V1, V2 och V4 | C | Gemensamt | ⬜ Ej startad | I-6, I-19 | Genererar input till I-15, I-17, I-10. |
 | [#119](https://github.com/Abdriano95/aegis/issues/119) (I-19) | Intervjuguide-revidering för iteration 3 | C | Gemensamt | ⬜ Ej startad | Inga | Styr I-18; ingen direkt rapportsektion. |
 | [#120](https://github.com/Abdriano95/aegis/issues/120) (I-20) | SSOT-uppdateringar för docs/arkitektur.md | B | Abdulla | ⬜ Ej startad | I-1–I-6 | SSOT (`docs/arkitektur.md`) synkas mot slutartefakten. |
-| [#142](https://github.com/Abdriano95/aegis/issues/142) (I-21) | Demo-dashboard: rapport/analys-fliksuppdelning, snapshot-väljare, version pinning-fix | A1 | Abdulla | ⬜ Ej startad | Inga | 5.1 uppdateras marginellt (demogränssnittets struktur); ingen designprincip-påverkan. |
+| [#142](https://github.com/Abdriano95/aegis/issues/142) (I-21) | Demo-dashboard: rapport/analys-fliksuppdelning, snapshot-väljare, version pinning-fix | A1 | Abdulla | ✅ Klar (2026-05-17) — rapport-flik pekar på `i7d_cross_validating.json`, ny analysflik, Article9 `latest`→v5 (status-filtrering); 246/246 tester gröna (se sessionspost 2026-05-17g) | Inga | 5.1 uppdateras marginellt (demogränssnittets struktur); ingen designprincip-påverkan. |
 | (I-7a) | Designspecifikation för Cross-Validating Aggregator (§9.6 evidensvägningspolicy) | B | Gemensamt | ✅ Klar (2026-05-15) — utkast i [`arkitektur_9_6_utkast.md`](arkitektur_9_6_utkast.md), väntar arkitekt-agent-granskning | Inga | Ny §9.6 i SSOT (`docs/arkitektur.md`); underlag för DP/arkitekturkapitel. |
 | (I-7b) | Implementation av Cross-Validating Aggregator (evidence_basis, generaliserad Mekanism 3, mode-flagga) | B | Gemensamt | ✅ Klar (2026-05-16) — §9.6 implementerad i kod, default `legacy`, 214/214 tester gröna; default-flipp efter I-7d (se sessionspost 2026-05-16) | I-7a, I-7c | Implementerar §9.6-policyn i kod; mätinstrumentändring → ombaslinje + Loggbok-beslut. |
 | (I-7c) | Ommappning `entity.spacy_LOC` → `context.plats` (omprövning av Beslut 11) | B | Gemensamt | ✅ Klar (2026-05-16) — `_label_map` LOC → `Category.PLATS` (source bevarad), §5 uppdaterad, 217/217 tester gröna; mätbar effekt → I-7d, matcher-alias kvarstår (omprövas efter I-7d) (se sessionspost 2026-05-16) | I-7a | §5 i SSOT uppdateras; matcher-alias `{ADRESS, PLATS}` omprövas. |
@@ -1540,3 +1540,49 @@ Probe-arbetet på Issue #107 är komplett. Inga ytterligare checkpoints planeras
 **Statustabell - ändrad.** #142 (I-21): ny rad ⬜ Ej startad.
 
 **Out of scope för denna session:** Kod, branch, git (commit/push/branch — användaren manuellt), Loggboken (ej redigerad), Beroendekartans ASCII-diagram (ej uppdaterad — kuraterad delmängd, ej begärt).
+
+### Session 2026-05-17g - Claude Code (Opus 4.7) — Issue #142 (I-21) implementerad (demo-dashboard-omarbete)
+
+**Iteration:** 3 / v0.3.0-dev
+
+**Mål:** Implementera I-21 enligt issue #142: rapportflik mot ny produktionssnapshot + rikare metadata, ny analysflik för snapshot-jämförelse, samt Article9 version pinning-fix.
+
+**Ändrade filer:**
+- `gdpr_classifier/prompts/loader.py` — status-filtrering i `_resolve_version` "latest"-gren; ny publik `resolve_prompt_version()`; defensiv YAML-läsning + logging.
+- `gdpr_classifier/layers/article9/article9_layer.py` — ny publik `prompt_version`-property (resolverar via loadern).
+- `demo/snapshot_loader.py` — `_SNAPSHOT_PATH` → `i7d_cross_validating.json`; `SnapshotData.evidence_basis_breakdown`; `load_snapshot_file()`; `SnapshotInfo` + `list_snapshots()`; inkompatibelt `per_dimension`-schema degraderas tyst.
+- `demo/snapshot_descriptions.py` — **ny** modul med kuraterade beskrivningar (23 toppnivå-snapshots) + fallback.
+- `demo/layout.py` — ny flik "Analys" mellan rapport och fritext; `analysis_tab_layout()`.
+- `demo/callbacks.py` — kuraterad metadata-rad + badges, evidence-basis-sektion, `tab-analysis`-gren, jämförelse-radbyggare + `update_analysis`-callback.
+- `tests/unit/test_prompt_loader.py` — `TestStatusFiltering` + `TestArticle9PromptVersionPinning`.
+- `docs/iteration_3_implementation.md` — status I-21 (🔄→✅) + denna sessionspost.
+
+**Gjort:**
+- Article9 `latest` resolverar nu till v5 (v6 hoppas via `status: experimental`); explicit `"v6"` opåverkad (probe/reproducerbarhet). Latent fritext-bugg (`build_pipeline` körde v6) åtgärdad automatiskt.
+- Rapportfliken laddar `i7d_cross_validating.json` (qwen3:14b, cross_validating) med modell-/mode-badges och evidence-basis-tabeller; befintlig rapportstruktur bevarad.
+- Analysfliken: två dropdowns från katalogskanning, A/B-metadata, jämförelse på fyra nivåer med färgkodade Δ-kolumner, nivå-togglar, evidence-basis-jämförelse, schemavarians-skydd ("Data saknas för denna nivå").
+- Verifiering: `pytest tests/` 246/246 gröna; pinning-introspektion (`resolve_prompt_version("article9","latest")=="v5"`); demo-app bootar (Flask test client 200, alla 5 callbacks registrerade); analys i7d↔iteration_2 renderar utan krasch.
+
+**Avvikelser prompt↔issue-body (issue-body vann på AC):** D1 23 (ej ~24) snapshots — dynamisk skanning, ingen påverkan. D2 `prompt_version`-property tillagd (krävs ordagrant av AC). D3 dropdown-etikett som superset (filnamn+modell+mode+subset). D4 evidence-basis renderat som TP/FP per mekanism (total + context_kombination_only + not) per faktisk datastruktur. D5 snapshots utan mode-fält visas som "legacy" (grå badge).
+
+**Beslut fattade:** Inga arkitekturbeslut (presentationsskikt + bugfix, per rapportens 5.1). Designdetaljer (prompt_version-property, evidence-basis-layout) godkända av användaren i Plan Mode.
+
+**Öppet/Nästa steg:** Manuell okulär kontroll av demon i webbläsare av användaren; git (add/commit `fixes #142`/push) hanteras manuellt.
+
+**Statustabell - ändrad.** #142 (I-21): 🔄 Pågår → ✅ Klar (2026-05-17).
+
+**Out of scope för denna session:** API-wrapper, långtextkorpus, sticky notes-cleanup utanför demo/pinning, fritextflikens UI/pipeline (utöver pinning-effekten), testdata-fliken, nya snapshots; git och Loggboken (användaren manuellt — designbesluten ej arkitektoniska).
+
+### Session 2026-05-17h - Claude Code (Opus 4.7) — Issue #142 (I-21) layout-polish
+
+**Iteration:** 3 / v0.3.0-dev
+
+**Mål:** Ren layout-justering av analysflikens metadata-block (ingen omöppning — I-21 förblir ✅ Klar).
+
+**Ändrade filer:**
+- `demo/callbacks.py` — ny hjälpare `_side_by_side()`; A/B-metadata och (när båda finns) evidence-basis-jämförelsen renderas nu i två likabreda flexkolumner istället för staplade.
+- `docs/iteration_3_implementation.md` — denna sessionspost.
+
+**Gjort:** Flexbox-wrappning (`display:flex`, `gap:16px`, `flexWrap:wrap`, kolumner `flex:1`/`minWidth:300px`) → A och B sida vid sida, stackar responsivt vid smalt fönster. `_metadata_row`/`_evidence_basis_section` återanvända oförändrade; jämförelsetabeller och Δ-kolumner orörda. Verifiering: `pytest tests/` 246/246, demo-app bootar (200), två-kolumns-rendering bekräftad (metadata + båda-EBB-fallet).
+
+**Statustabell - oförändrad.** #142 (I-21) kvarstår ✅ Klar (polish).

--- a/docs/iteration_3_implementation.md
+++ b/docs/iteration_3_implementation.md
@@ -1586,3 +1586,18 @@ Probe-arbetet på Issue #107 är komplett. Inga ytterligare checkpoints planeras
 **Gjort:** Flexbox-wrappning (`display:flex`, `gap:16px`, `flexWrap:wrap`, kolumner `flex:1`/`minWidth:300px`) → A och B sida vid sida, stackar responsivt vid smalt fönster. `_metadata_row`/`_evidence_basis_section` återanvända oförändrade; jämförelsetabeller och Δ-kolumner orörda. Verifiering: `pytest tests/` 246/246, demo-app bootar (200), två-kolumns-rendering bekräftad (metadata + båda-EBB-fallet).
 
 **Statustabell - oförändrad.** #142 (I-21) kvarstår ✅ Klar (polish).
+
+### Session 2026-05-17i - Claude Code (Opus 4.7) — Issue #142 (I-21) CodeRabbit-granskningsfixar (PR #143)
+
+**Iteration:** 3 / v0.3.0-dev
+
+**Mål:** Åtgärda CodeRabbits PR-granskning av #143 (ingen omöppning — I-21 förblir ✅ Klar).
+
+**Ändrade filer:**
+- `demo/snapshot_loader.py` — `load_snapshot_file()`: `not path.is_file()`-gard; except breddad till `(json.JSONDecodeError, OSError, KeyError, TypeError, ValueError)` så en enskild trasig snapshot aldrig avbryter `list_snapshots()` (täcker I/O-fel + schemadrift-`TypeError` i `_rehydrate_report`).
+- `gdpr_classifier/prompts/loader.py` — `_resolve_version` "latest"-probing fångar nu även `UnicodeError` (icke-UTF8-promptfil → hoppas i stället för att avbryta resolveringen; meddelandet bevarat så befintligt `test_malformed_yaml` ej regredierar).
+- `docs/iteration_3_implementation.md` — denna sessionspost.
+
+**Gjort:** Två Major-fynd (robusthet, sammanföll med vår egen dokumenterade "hoppa trasig indata, krascha ej"-intention) åtgärdade. Två Minor-fynd avböjda med motivering kommenterade på PR:en: (1) nolldelta `+0.0 pp` grönt — kosmetiskt, endast vid exakt lika mätvärden, defererat; (2) RUF001 Unicode-minus — ingen Ruff/CI-lint-gate i repot, kodbasen använder `Δ`/`—`/`·` genomgående, repo-bred policyfråga utanför I-21. Verifiering: `pytest tests/` 246/246 grönt; `list_snapshots()` 23, katalog-/saknad-sökväg → `None`, `resolve_prompt_version("article9","latest")=="v5"`.
+
+**Statustabell - oförändrad.** #142 (I-21) kvarstår ✅ Klar (granskningsfixar, ingen omöppning).

--- a/gdpr_classifier/layers/article9/article9_layer.py
+++ b/gdpr_classifier/layers/article9/article9_layer.py
@@ -6,7 +6,7 @@ import logging
 
 from ...core.category import Category
 from ...core.finding import Finding
-from ...prompts.loader import load_prompt
+from ...prompts.loader import load_prompt, resolve_prompt_version
 from ..llm.provider import LLMProvider
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,17 @@ class Article9Layer:
     def name(self) -> str:
         """Name of the layer."""
         return "article9"
+
+    @property
+    def prompt_version(self) -> str:
+        """The concrete prompt version this layer resolves to.
+
+        For the default ``"latest"`` request this applies the loader's
+        ``status: "experimental"`` filtering (e.g. resolves to ``"v5"`` while
+        article9 v6 is experimental). An explicitly pinned version is returned
+        as-is. Resolution is a pure filesystem read; the provider is not used.
+        """
+        return resolve_prompt_version("article9", self._prompt_version)
 
     def detect(self, text: str) -> list[Finding]:
         """Detect Article 9 data in the provided text.

--- a/gdpr_classifier/prompts/loader.py
+++ b/gdpr_classifier/prompts/loader.py
@@ -199,7 +199,11 @@ def _resolve_version(layer_dir: Path, version: str, prompts_root: Path) -> Path:
         for _, path in candidates:
             try:
                 data = yaml.safe_load(path.read_text(encoding="utf-8"))
-            except (yaml.YAMLError, OSError) as exc:
+            except (yaml.YAMLError, UnicodeError, OSError) as exc:
+                # UnicodeError (e.g. invalid UTF-8) is a ValueError, not an
+                # OSError — catch it explicitly so a non-decodable candidate
+                # is skipped (per the design intent above) instead of
+                # aborting "latest" resolution.
                 _LOG.warning("Skipping unreadable prompt candidate %s: %s", path, exc)
                 last_load_error = PromptLoadError(
                     f"YAML parse error in {path}: {exc}"

--- a/gdpr_classifier/prompts/loader.py
+++ b/gdpr_classifier/prompts/loader.py
@@ -28,11 +28,14 @@ References:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 import re
 
 import yaml
+
+_LOG = logging.getLogger(__name__)
 
 
 # --- Exceptions ---
@@ -110,6 +113,42 @@ def load_prompt(
         PromptValidationError: If required fields are missing, fields have
             wrong types, or examples have invalid structure.
     """
+    yaml_path = _resolve_yaml_path(layer, version, base_dir)
+    raw = _load_yaml(yaml_path)
+    _validate(raw, yaml_path)
+
+    return Prompt(
+        metadata=raw["metadata"],
+        system_prompt=raw["system_prompt"].strip(),
+        assembled_prompt=_assemble(raw),
+    )
+
+
+def resolve_prompt_version(
+    layer: str,
+    version: str = "latest",
+    base_dir: Path | None = None,
+) -> str:
+    """Resolve a version request to the concrete version string it selects.
+
+    Mirrors :func:`load_prompt`'s path resolution (including the
+    ``status: "experimental"`` filtering applied to ``"latest"``) but only
+    returns the version stem (e.g. ``"v5"``) without loading or validating
+    the prompt body. ``base_dir`` exists for test dependency injection.
+
+    Raises:
+        PromptLoadError: Same conditions as :func:`load_prompt` path resolution.
+    """
+    return _resolve_yaml_path(layer, version, base_dir).stem
+
+
+# --- Internal helpers ---
+
+
+def _resolve_yaml_path(
+    layer: str, version: str, base_dir: Path | None
+) -> Path:
+    """Validate the layer and resolve ``version`` to a concrete YAML path."""
     prompts_dir = base_dir if base_dir is not None else _PROMPTS_DIR
     resolved_prompts_dir = prompts_dir.resolve()
 
@@ -124,18 +163,7 @@ def load_prompt(
     if not layer_dir.is_dir():
         raise PromptLoadError(f"Layer directory not found: {layer_dir}")
 
-    yaml_path = _resolve_version(layer_dir, version, resolved_prompts_dir)
-    raw = _load_yaml(yaml_path)
-    _validate(raw, yaml_path)
-
-    return Prompt(
-        metadata=raw["metadata"],
-        system_prompt=raw["system_prompt"].strip(),
-        assembled_prompt=_assemble(raw),
-    )
-
-
-# --- Internal helpers ---
+    return _resolve_version(layer_dir, version, resolved_prompts_dir)
 
 
 def _resolve_version(layer_dir: Path, version: str, prompts_root: Path) -> Path:
@@ -160,8 +188,42 @@ def _resolve_version(layer_dir: Path, version: str, prompts_root: Path) -> Path:
             raise PromptLoadError(
                 f"No valid versioned prompt files (vN.yaml) found in {layer_dir}"
             )
-        candidates.sort(key=lambda x: x[0])
-        return candidates[-1][1]
+        # Highest version first; skip versions marked experimental in their
+        # YAML metadata. Explicit version requests (handled below) bypass this
+        # so probe/reproducibility runs can still pin an experimental prompt.
+        # Malformed candidates are skipped so a valid lower version can still
+        # be selected, but the parse error is preserved and re-raised if no
+        # valid candidate remains (keeps diagnostics for the all-broken case).
+        candidates.sort(key=lambda x: x[0], reverse=True)
+        last_load_error: PromptLoadError | None = None
+        for _, path in candidates:
+            try:
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except (yaml.YAMLError, OSError) as exc:
+                _LOG.warning("Skipping unreadable prompt candidate %s: %s", path, exc)
+                last_load_error = PromptLoadError(
+                    f"YAML parse error in {path}: {exc}"
+                )
+                continue
+            if not isinstance(data, dict):
+                _LOG.warning(
+                    "Skipping prompt candidate %s: top-level YAML is not a mapping",
+                    path,
+                )
+                last_load_error = PromptLoadError(
+                    f"Expected YAML mapping at top level in {path}, "
+                    f"got {type(data).__name__}"
+                )
+                continue
+            metadata = data.get("metadata")
+            if isinstance(metadata, dict) and metadata.get("status") == "experimental":
+                continue
+            return path
+        if last_load_error is not None:
+            raise last_load_error
+        raise PromptLoadError(
+            f"No non-experimental versioned prompt files found in {layer_dir}"
+        )
 
     # Explicit version
     path = (layer_dir / f"{version}.yaml").resolve()

--- a/tests/unit/test_prompt_loader.py
+++ b/tests/unit/test_prompt_loader.py
@@ -11,13 +11,18 @@ Tests cover:
 - Loading with only required fields (optional fields omitted)
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
+from gdpr_classifier.layers.article9 import Article9Layer
+from gdpr_classifier.layers.llm.provider import LLMProvider
 from gdpr_classifier.prompts.loader import (
     Prompt,
     PromptLoadError,
     PromptValidationError,
     load_prompt,
+    resolve_prompt_version,
 )
 
 
@@ -274,3 +279,95 @@ class TestOptionalFieldsOmitted:
         assert "Return JSON" in prompt.assembled_prompt
         # No examples or reasoning in minimal prompt
         assert "--- Examples ---" not in prompt.assembled_prompt
+
+
+# --- Version-pinning: status filtering for "latest" ---
+
+
+def _versioned(version: str, *, experimental: bool = False) -> str:
+    """Return _VALID_YAML re-stamped to ``version``, optionally experimental."""
+    meta = f'version: "{version}"'
+    if experimental:
+        meta += '\n  status: "experimental"'
+    return _VALID_YAML.replace('version: "v1"', meta)
+
+
+class TestStatusFiltering:
+    """version='latest' must skip prompts marked status: experimental."""
+
+    def test_latest_skips_experimental(self, tmp_path):
+        _write_prompt(tmp_path, "test_layer", "v1", _versioned("v1"))
+        _write_prompt(
+            tmp_path, "test_layer", "v2", _versioned("v2", experimental=True)
+        )
+
+        prompt = load_prompt("test_layer", version="latest", base_dir=tmp_path)
+        assert prompt.metadata["version"] == "v1"
+        assert (
+            resolve_prompt_version("test_layer", "latest", base_dir=tmp_path)
+            == "v1"
+        )
+
+    def test_missing_status_treated_as_active(self, tmp_path):
+        _write_prompt(tmp_path, "test_layer", "v1", _versioned("v1"))
+        _write_prompt(tmp_path, "test_layer", "v2", _versioned("v2"))
+
+        assert (
+            resolve_prompt_version("test_layer", "latest", base_dir=tmp_path)
+            == "v2"
+        )
+
+    def test_explicit_version_ignores_status(self, tmp_path):
+        _write_prompt(tmp_path, "test_layer", "v1", _versioned("v1"))
+        _write_prompt(
+            tmp_path, "test_layer", "v2", _versioned("v2", experimental=True)
+        )
+
+        prompt = load_prompt("test_layer", version="v2", base_dir=tmp_path)
+        assert prompt.metadata["version"] == "v2"
+        assert (
+            resolve_prompt_version("test_layer", "v2", base_dir=tmp_path) == "v2"
+        )
+
+    def test_malformed_candidate_skipped(self, tmp_path, caplog):
+        _write_prompt(tmp_path, "test_layer", "v1", _versioned("v1"))
+        _write_prompt(
+            tmp_path, "test_layer", "v2", "metadata:\n  version: [unterminated"
+        )
+
+        with caplog.at_level("WARNING"):
+            version = resolve_prompt_version(
+                "test_layer", "latest", base_dir=tmp_path
+            )
+        assert version == "v1"
+        assert any("v2.yaml" in r.message for r in caplog.records)
+
+    def test_all_experimental_raises(self, tmp_path):
+        _write_prompt(
+            tmp_path, "test_layer", "v1", _versioned("v1", experimental=True)
+        )
+        _write_prompt(
+            tmp_path, "test_layer", "v2", _versioned("v2", experimental=True)
+        )
+
+        with pytest.raises(PromptLoadError, match="non-experimental"):
+            resolve_prompt_version("test_layer", "latest", base_dir=tmp_path)
+
+
+class TestArticle9PromptVersionPinning:
+    """Article9Layer.prompt_version must resolve away experimental article9 v6.
+
+    Runs against the real prompts directory. The provider is never invoked by
+    the property (resolution is a pure filesystem read).
+    """
+
+    def test_latest_resolves_to_v5(self):
+        layer = Article9Layer(MagicMock(spec=LLMProvider))
+        assert layer.prompt_version == "v5"
+
+    def test_explicit_v6_is_preserved(self):
+        layer = Article9Layer(MagicMock(spec=LLMProvider), prompt_version="v6")
+        assert layer.prompt_version == "v6"
+
+    def test_resolver_helper_on_real_article9(self):
+        assert resolve_prompt_version("article9", "latest") == "v5"


### PR DESCRIPTION
# I-21 (#142): Demo-dashboard — rapport/analys-fliksuppdelning, snapshot-väljare, version pinning-fix

> Föreslagen PR-titel ↑ (scratch-fil, ej avsedd att committas — radera efter att PR-texten klistrats in)

## Sammanfattning

Omarbete av demogränssnittet inför iteration 3:s naturalistiska utvärdering (V1, V2, V4) samt en latent bugg-fix i prompt-resolveringen. Tre samverkande ändringar:

1. **Rapportfliken** pekas om från `iteration_3_post_I5_fixup.json` (qwen2.5, legacy) till produktionssnapshoten `i7d_cross_validating.json` (qwen3:14b, cross_validating, post-I-7g, article9 v5 / combination v5), med kuraterad metadata-rad och `evidence_basis_breakdown`.
2. **Ny analysflik** för snapshot-jämförelse mellan två valbara snapshots.
3. **Version pinning-fix**: `_resolve_version` hoppar `status: experimental`-versioner i `"latest"`-grenen → Article9 `latest` resolverar nu v5 (var v6). Åtgärdar latent bugg där fritext-demon körde den tillbakarullade v6-prompten (Beslut 48).

Stänger #142. Spår A1. Berör inte `gdpr_classifier/core/` → ingen koordinationsregel med Johanna.

## Arbetspaket 1 — Rapportfliken

- `demo/snapshot_loader.py`: `_SNAPSHOT_PATH` → `i7d_cross_validating.json`; `SnapshotData.evidence_basis_breakdown`; `load_snapshot()` delegerar till ny `load_snapshot_file(path)`.
- `demo/callbacks.py`: kuraterad metadata-rad med modell-badge (blå) + aggregator-mode-badge (grön `cross_validating` / grå `legacy`) + etiketterad text (datum · commit · subset · texter · prompt-versioner). Ny evidence-basis-sektion (TP/FP per mekanism: `total` + `context_kombination_only` + `note`, defensiv fallback). Befintlig rapportstruktur (total/kategori/lager/dimension/FP/FN) oförändrad.

## Arbetspaket 2 — Analysflik (ny)

- Ny flik **"Analys"** i `dcc.Tabs` mellan rapport och fritext (`demo/layout.py`).
- Två `dcc.Dropdown` (A/B) fyllda från katalogskanning (`list_snapshots()`): endast toppnivå-`*.json`, ladd-/rehydrerbara (exkluderar `pre_num_ctx_fix/`, `.log`, `.gitkeep`).
- Ny modul `demo/snapshot_descriptions.py`: 23 kuraterade svenska beskrivningar + säker fallback.
- A/B-metadata (samma kuraterade vy) renderade **side-by-side** i responsiva flexkolumner.
- Jämförelsetabeller på fyra nivåer (total, per-kategori, per-lager, per-dimension) med färgkodade Δ P/R/F1-kolumner; nivå-togglar (default total + per-kategori).
- Evidence-basis-jämförelse side-by-side när båda har fältet; en-sidig notis annars.
- Schemavarians-skydd: saknad nivå (inkl. pre-I-5 `per_dimension`-schema) → "Data saknas för denna nivå" istället för krasch.

## Arbetspaket 3 — Version pinning-fix

- `gdpr_classifier/prompts/loader.py`: `_resolve_version` `"latest"`-gren läser `metadata.status`, hoppar `experimental`; malformade kandidater hoppas men parse-felet bevaras och återkastas om ingen giltig version finns (bakåtkompatibelt — befintligt `test_malformed_yaml` grönt). Ny publik `resolve_prompt_version()` + extraherad `_resolve_yaml_path()`. Explicit version (t.ex. `"v6"`) opåverkad.
- `gdpr_classifier/layers/article9/article9_layer.py`: ny publik `prompt_version`-property (resolverar via loadern; ingen provider-anrop).

## Avvikelser mot ursprungsspec (issue-bodyn vann på AC, prompten på designdetaljer)

- **D1**: 23 (ej ~24) toppnivå-snapshots — dynamisk skanning, ingen påverkan.
- **D2**: publik `Article9Layer.prompt_version`-property tillagd (AC krävde uttrycket ordagrant).
- **D3**: dropdown-etikett som superset: `<beskrivning> — <filnamn> · <modell> · <mode> · <subset>`.
- **D4**: evidence_basis renderat enligt faktisk datastruktur (TP/FP per mekanism, två block + not).
- **D5**: snapshots utan `mode`-fält → grå "legacy"-badge.

Dokumenterat i `## Implementationsnoteringar` i issue #142 och sessionsposter 2026-05-17g/h.

## Verifiering

- **`pytest tests/` → 246/246 gröna** (inkl. nya `TestStatusFiltering` + `TestArticle9PromptVersionPinning`; befintliga loader-tester orörda).
- Deterministisk end-to-end-kontroll på callback-/pipeline-nivå:
  - Rapport: `_SNAPSHOT_PATH` = i7d_cross_validating.json, commit 8144ae13, Totalt P 82.88 / R 91.42 / F1 86.94; renderad EBB-tabell == rå JSON.
  - Analys: 23 options, side-by-side metadata, Δ-aritmetik oberoende verifierad (F1 −12.4 pp), schemavarians- + en-sidig-EBB-notis, A-vs-A == +0.0 pp.
  - Fritext: `build_pipeline()`-instansens `Article9Layer.prompt_version == "v5"` (v6 = experimental).
- Demo-appen bootar (Flask-testklient HTTP 200, alla 5 callbacks registrerade).

## Filer ändrade (8, +871/−46)

`demo/callbacks.py`, `demo/layout.py`, `demo/snapshot_descriptions.py` (ny), `demo/snapshot_loader.py`, `gdpr_classifier/layers/article9/article9_layer.py`, `gdpr_classifier/prompts/loader.py`, `tests/unit/test_prompt_loader.py`, `docs/iteration_3_implementation.md` (status I-21 → ✅ Klar + sessionsposter).

## Out of scope

API-wrapper, långtextkorpus, sticky notes-cleanup utanför demo/pinning, fritextflikens UI/pipeline (utöver pinning-effekten), testdata-fliken, nya snapshots.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Analysis tab for comparing analysis snapshots side-by-side with metadata, category details, and dimensional breakdowns
  * Enhanced snapshot metadata display with descriptive labels and visual badges
  * Added evidence-basis breakdown sections to reports

* **Improvements**
  * Improved prompt version resolution to automatically skip experimental versions for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abdriano95/aegis/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->