### PR TITLE
demo: lägg till iteration 3-demotexter (HÖG/MEDEL/LÅG) i Fritext-analys

### DIFF
--- a/demo/layout.py
+++ b/demo/layout.py
@@ -19,6 +19,57 @@ _DEMO_TEXTS = {
         "Den nya rektorn på Hvitfeldtska gymnasiets fick utmärkelsen "
         "i fjol efter sitt arbete med ensembleundervisning."
     ),
+    "Text 4: HÖG": (
+        "Internt HR-ärende 2026-0418, sammanställning inför uppföljningsmöte\n\n"
+        "Medarbetare: Karin Lindqvist, anställd som logistiksamordnare sedan "
+        "2019. Kontaktuppgifter enligt personalsystemet: "
+        "karin.lindqvist@nordstromlogistik.se, mobil 070-413 88 21.\n\n"
+        "Bakgrund: Karin har varit sjukskriven på heltid sedan den 3 mars efter "
+        "att företagshälsovården ställt diagnosen utmattningssyndrom. Två "
+        "rehabiliteringssamtal har hållits. Karin uppger att hon under perioden "
+        "även genomgått utredning för en kronisk inflammatorisk tarmsjukdom och "
+        "att hon medicinerar dagligen, samt att hon av hälsoskäl behöver slippa "
+        "nattskift.\n\n"
+        "Vid det senaste samtalet nämnde Karin att hon och hennes fru planerar "
+        "att flytta närmare arbetsplatsen för att korta restiden. Hon bad också "
+        "om att få gå ifrån en eftermiddag i månaden för möten i den lokala "
+        "församling där hon är aktiv, och önskade ledigt för att fira en högtid "
+        "med familjen i mitten av maj.\n\n"
+        "Chefens bedömning och planerad åtgärd dokumenteras separat. Ärendet "
+        "följs upp vid nästa möte."
+    ),
+    "Text 5: MEDEL": (
+        "Visselblåsarrapport, inkommen 2026-05-09 via extern "
+        "rapporteringskanal, anonym anmälare\n\n"
+        "Anmälan rör påstådda missförhållanden i en offentlig verksamhet. "
+        "Anmälaren har valt att inte uppge namn eller kontaktuppgifter.\n\n"
+        "Personen som anmälan gäller namnges aldrig i underlaget, men beskrivs "
+        "enligt följande: hen är regionens enda barnkardiolog, arbetar vid "
+        "Region Bergslagens enhet i Degerfors och har enligt anmälaren suttit i "
+        "den lokala fackklubbens styrelse de senaste fyra åren. Anmälaren uppger "
+        "vidare att personen var sjukskriven under hösten och att flera kollegor "
+        "kände till orsaken.\n\n"
+        "Anmälaren beskriver ett upprepat agerande som anmälaren menar avviker "
+        "från verksamhetens rutiner. Ingen brottsrubricering anges.\n\n"
+        "Notering från mottagningsfunktionen: underlaget innehåller inga direkta "
+        "identifikationsuppgifter, men kombinationen av yrkesroll, arbetsgivare "
+        "och ort är ovanligt specifik."
+    ),
+    "Text 6: LÅG": (
+        "Anonymiserad fallbeskrivning, internt utbildningsmaterial i "
+        "bemötande\n\n"
+        "En patient i 50-årsåldern söker vård för återkommande ledvärk och "
+        "trötthet. Patienten har sedan tidigare en autoimmun diagnos och "
+        "behandlas med immundämpande läkemedel. Av anteckningen framgår att "
+        "patienten nyligen kommit till Sverige, att tolk anlitades och att "
+        "patienten uppger att liknande besvär är vanliga i släkten.\n\n"
+        "Vårdcentralen i Hjo remitterade patienten vidare till sjukhuset i "
+        "Skövde för utredning. Uppföljning planeras i samband med en kommande "
+        "patientutbildning på konferensen i höst.\n\n"
+        "Fallet används enbart i utbildningssyfte. Inga namn, personnummer eller "
+        "kontaktuppgifter förekommer, och beskrivningen är medvetet generell så "
+        "att ingen enskild person kan identifieras."
+    ),
 }
 
 

--- a/docs/iteration_3_implementation.md
+++ b/docs/iteration_3_implementation.md
@@ -1617,3 +1617,21 @@ Probe-arbetet på Issue #107 är komplett. Inga ytterligare checkpoints planeras
 **Beslut fattade:** Inga (rent dokumentationsunderlag; designbeslut hör till Loggboken, ej här).
 
 **Öppet/Nästa steg:** Abdulla/Johanna formulerar om till rapportprosa i 4.1.x. Git (add/commit/push) hanteras manuellt av teamet — ingen commit i denna session.
+
+### Session 2026-05-19 - Claude Code (Opus 4.7) — Demotexter iteration 3 i Fritext-analys-vyn
+
+**Iteration:** 3 / v0.3.0-dev
+
+**Mål:** Lägga till tre nya syntetiska demotexter i Fritext-analys-vyn som tydligt triggar iteration 3:s leveranser, märkta med härledd känslighetsnivå, som demonstrationsunderlag inför I-18:s naturalistiska utvärdering. Ej en numrerad issue — ingen statustabellsändring.
+
+**Ändrade filer:**
+- `demo/layout.py` — `_DEMO_TEXTS` utökad 3 → 6 poster.
+- `docs/iteration_3_implementation.md` — denna sessionspost.
+
+**Gjort:** Lade till `Text 4: HÖG` (HR-ärende: direkt identifierare + artikel 9 → HÖG; lång text som även exercerar kontextfönster-fixen, Beslut 50), `Text 5: MEDEL` (anonym visselblåsarrapport: indirekt identifierbar via pusselbitar + artikel 9 → MEDEL; visar plats-omklassning Beslut 53 och Cross-Validating Aggregatorns transparensmärkning I-7a–g) och `Text 6: LÅG` (generisk fallbeskrivning: ingen identifierbar person + artikel 9 → LÅG; överklassificeringsskydd via tvådimensionsmodellen Beslut 37/49 + bortfall av falska adressfynd). Samtliga texter är syntetiska. Knapparna och `fill_demo_text`-callbacken är datadrivna från `_DEMO_TEXTS` (layout via `enumerate`, callback via `range(len(...))`), så de tre nya knapparna autokopplas utan callback-ändring. Befintliga Text 1–3 orörda. Verifiering: `ast.parse` + import rent, `freetext_tab_layout()` bygger sex knappar (nya texter 1009 / 892 / 756 tecken), inga tester refererar dicten.
+
+**Beslut fattade:** Inga (demo-innehåll; inga arkitektur- eller designbeslut).
+
+**Öppet/Nästa steg:** Kör de tre texterna genom pipelinen och pinna dem i en demo-ögonblicksbild före I-18-mötet, eftersom artikel 9- och kombinationslagren är LLM-drivna och inte fullt deterministiska. Fler/större varianter (t.ex. flersidig kontextfönster-text eller kontrasttext utan strukturellt stöd) kan tas fram på begäran.
+
+**Statustabell - oförändrad.** Demo-prep inför I-18; ej en spårad I-row, ingen statustabellsändring (samma princip som sessionen 2026-05-18).


### PR DESCRIPTION
Utökar _DEMO_TEXTS 3->6 så Fritext-analys-vyn exercerar iteration 3:s leveranser (tvådimensionsmodell, Cross-Validating-transparens, plats-omklassning) inför I-18:s naturalistiska utvärdering. Knappar och fill_demo_text är datadrivna från dicten; ingen callback-ändring. Syntetiskt innehåll; Text 1-3 orörda.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new demonstration texts with distinct sensitivity level classifications to the demo interface for expanded testing and evaluation coverage.

* **Documentation**
  * Updated documentation to describe the new demo texts and their integration with the analysis interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Abdriano95/aegis/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->